### PR TITLE
Remove a layer of nesting unnecessary

### DIFF
--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -28,21 +28,22 @@ impl Strkey {
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
 pub enum PublicKey {
-    Ed25519(PublicKeyEd25519),
+    Ed25519([u8; 32]),
 }
 
 impl PublicKey {
     pub fn to_string(&self) -> String {
         match self {
-            Self::Ed25519(x) => x.to_string(),
+            Self::Ed25519(x) => encode(Version::PublicKeyEd25519, x),
         }
     }
 
     fn from_version_and_payload(ver: Version, payload: &[u8]) -> Result<Self, DecodeError> {
         match ver {
-            Version::PublicKeyEd25519 => Ok(Self::Ed25519(
-                PublicKeyEd25519::from_version_and_payload(ver, payload)?,
-            )),
+            Version::PublicKeyEd25519 => match payload.try_into() {
+                Ok(ed25519) => Ok(Self::Ed25519(ed25519)),
+                Err(_) => Err(DecodeError::Invalid),
+            },
         }
     }
 

--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -34,7 +34,7 @@ pub enum PublicKey {
 impl PublicKey {
     pub fn to_string(&self) -> String {
         match self {
-            Self::Ed25519(x) => encode(Version::PublicKeyEd25519, x),
+            Self::Ed25519(k) => encode(Version::PublicKeyEd25519, k),
         }
     }
 
@@ -42,29 +42,6 @@ impl PublicKey {
         match ver {
             Version::PublicKeyEd25519 => match payload.try_into() {
                 Ok(ed25519) => Ok(Self::Ed25519(ed25519)),
-                Err(_) => Err(DecodeError::Invalid),
-            },
-        }
-    }
-
-    pub fn from_string(s: &str) -> Result<Self, DecodeError> {
-        let (ver, payload) = decode(s)?;
-        Self::from_version_and_payload(ver, &payload)
-    }
-}
-
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
-pub struct PublicKeyEd25519(pub [u8; 32]);
-
-impl PublicKeyEd25519 {
-    pub fn to_string(&self) -> String {
-        encode(Version::PublicKeyEd25519, &self.0)
-    }
-
-    fn from_version_and_payload(ver: Version, payload: &[u8]) -> Result<Self, DecodeError> {
-        match ver {
-            Version::PublicKeyEd25519 => match payload.try_into() {
-                Ok(ed25519) => Ok(Self(ed25519)),
                 Err(_) => Err(DecodeError::Invalid),
             },
         }

--- a/tests/public_key_ed25519.rs
+++ b/tests/public_key_ed25519.rs
@@ -8,11 +8,11 @@ fn test_public_key_ed25519_from_string() {
     let r = Strkey::from_string("GA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQHES5");
     assert_eq!(
         r,
-        Ok(Strkey::PublicKey(PublicKey::Ed25519(PublicKeyEd25519([
+        Ok(Strkey::PublicKey(PublicKey::Ed25519([
             0x36, 0x3e, 0xaa, 0x38, 0x67, 0x84, 0x1f, 0xba, 0xd0, 0xf4, 0xed, 0x88, 0xc7, 0x79,
             0xe4, 0xfe, 0x66, 0xe5, 0x6a, 0x24, 0x70, 0xdc, 0x98, 0xc0, 0xec, 0x9c, 0x07, 0x3d,
             0x05, 0xc7, 0xb1, 0x03,
-        ]))))
+        ])))
     );
 
     // Invalid length (Ed25519 should be 32 bytes, not 5).
@@ -42,11 +42,11 @@ proptest! {
 #[test]
 fn test_public_key_ed25519_to_string() {
     // Valid account.
-    let r = Strkey::PublicKey(PublicKey::Ed25519(PublicKeyEd25519([
+    let r = Strkey::PublicKey(PublicKey::Ed25519([
         0x36, 0x3e, 0xaa, 0x38, 0x67, 0x84, 0x1f, 0xba, 0xd0, 0xf4, 0xed, 0x88, 0xc7, 0x79, 0xe4,
         0xfe, 0x66, 0xe5, 0x6a, 0x24, 0x70, 0xdc, 0x98, 0xc0, 0xec, 0x9c, 0x07, 0x3d, 0x05, 0xc7,
         0xb1, 0x03,
-    ])))
+    ]))
     .to_string();
     assert_eq!(
         r,
@@ -57,6 +57,6 @@ fn test_public_key_ed25519_to_string() {
 proptest! {
     #[test]
     fn test_public_key_ed25519_to_string_doesnt_panic(data: [u8; 32]) {
-        Strkey::PublicKey(PublicKey::Ed25519(PublicKeyEd25519(data))).to_string();
+        Strkey::PublicKey(PublicKey::Ed25519(data)).to_string();
     }
 }


### PR DESCRIPTION
### What

Flatten the ed25519 type into the enum.

### Why

The extra layer of type nesting is unnecessary.

### Known limitations

N/A