### PR TITLE
refactor tests

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,7 +5,7 @@ use proptest::prelude::*;
 #[test]
 fn test_valid_public_keys() {
     // Valid account.
-    test_valid_strkey_roundtrip(
+    assert_convert_roundtrip(
         "GA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQHES5",
         &Strkey::PublicKey(PublicKey([
             0x36, 0x3e, 0xaa, 0x38, 0x67, 0x84, 0x1f, 0xba, 0xd0, 0xf4, 0xed, 0x88, 0xc7, 0x79,
@@ -48,8 +48,8 @@ proptest! {
     }
 }
 
-fn test_valid_strkey_roundtrip(str: &str, strkey: &Strkey) {
-    let strkey_result = Strkey::from_string(&str).unwrap();
+fn assert_convert_roundtrip(s: &str, strkey: &Strkey) {
+    let strkey_result = Strkey::from_string(&s).unwrap();
     assert_eq!(&strkey_result, strkey);
     let str_result = strkey.to_string();
     assert_eq!(str_result, str_result)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3,18 +3,20 @@ extern crate proptest;
 use proptest::prelude::*;
 
 #[test]
-fn test_public_key_ed25519_from_string() {
+fn test_valid_public_keys() {
     // Valid account.
-    let r = Strkey::from_string("GA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQHES5");
-    assert_eq!(
-        r,
-        Ok(Strkey::PublicKey(PublicKey([
+    test_valid_strkey_roundtrip(
+        "GA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQHES5",
+        &Strkey::PublicKey(PublicKey([
             0x36, 0x3e, 0xaa, 0x38, 0x67, 0x84, 0x1f, 0xba, 0xd0, 0xf4, 0xed, 0x88, 0xc7, 0x79,
             0xe4, 0xfe, 0x66, 0xe5, 0x6a, 0x24, 0x70, 0xdc, 0x98, 0xc0, 0xec, 0x9c, 0x07, 0x3d,
             0x05, 0xc7, 0xb1, 0x03,
-        ])))
+        ])),
     );
+}
 
+#[test]
+fn test_invalid_public_keys() {
     // Invalid length (Ed25519 should be 32 bytes, not 5).
     let r = Strkey::from_string("GAAAAAAAACGC6");
     assert_eq!(r, Err(DecodeError::Invalid));
@@ -39,24 +41,16 @@ proptest! {
     }
 }
 
-#[test]
-fn test_public_key_ed25519_to_string() {
-    // Valid account.
-    let r = Strkey::PublicKey(PublicKey([
-        0x36, 0x3e, 0xaa, 0x38, 0x67, 0x84, 0x1f, 0xba, 0xd0, 0xf4, 0xed, 0x88, 0xc7, 0x79, 0xe4,
-        0xfe, 0x66, 0xe5, 0x6a, 0x24, 0x70, 0xdc, 0x98, 0xc0, 0xec, 0x9c, 0x07, 0x3d, 0x05, 0xc7,
-        0xb1, 0x03,
-    ]))
-    .to_string();
-    assert_eq!(
-        r,
-        "GA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQHES5",
-    );
-}
-
 proptest! {
     #[test]
     fn test_public_key_ed25519_to_string_doesnt_panic(data: [u8; 32]) {
         Strkey::PublicKey(PublicKey(data)).to_string();
     }
+}
+
+fn test_valid_strkey_roundtrip(str: &str, strkey: &Strkey) {
+    let strkey_result = Strkey::from_string(&str).unwrap();
+    assert_eq!(&strkey_result, strkey);
+    let str_result = strkey.to_string();
+    assert_eq!(str_result, str_result)
 }


### PR DESCRIPTION
add valid roundtrip test helper
consolidate to a single tests.rs file (other strkey implementations seem to fit their tests nicely in a single file)
