### PR TITLE
Avoid redecoding unnecessarily

### DIFF
--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -21,7 +21,9 @@ impl Strkey {
     pub fn from_string(s: &str) -> Result<Self, DecodeError> {
         let (ver, payload) = decode(s)?;
         match ver {
-            Version::PublicKeyEd25519 => Ok(Self::PublicKey(PublicKey::from_version_and_payload(ver, &payload)?)),
+            Version::PublicKeyEd25519 => Ok(Self::PublicKey(PublicKey::from_version_and_payload(
+                ver, &payload,
+            )?)),
         }
     }
 }

--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -19,9 +19,9 @@ impl Strkey {
     }
 
     pub fn from_string(s: &str) -> Result<Self, DecodeError> {
-        let (ver, _) = decode(s)?;
+        let (ver, payload) = decode(s)?;
         match ver {
-            Version::PublicKeyEd25519 => Ok(Self::PublicKey(PublicKey::from_string(s)?)),
+            Version::PublicKeyEd25519 => Ok(Self::PublicKey(PublicKey::from_version_and_payload(ver, &payload)?)),
         }
     }
 }


### PR DESCRIPTION
### What

When decoding a strkey pass the partially decoded ver and payload to the subtypes.

### Why

Avoid redecoding unnecessarily.

### Known limitations

N/A
