### PR TITLE
Remove the Version enum

### DIFF
--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -21,9 +21,10 @@ impl Strkey {
     pub fn from_string(s: &str) -> Result<Self, DecodeError> {
         let (ver, payload) = decode(s)?;
         match ver {
-            Version::PublicKeyEd25519 => Ok(Self::PublicKey(PublicKey::from_version_and_payload(
-                ver, &payload,
-            )?)),
+            version::PUBLIC_KEY_ED25519 => Ok(Self::PublicKey(
+                PublicKey::from_version_and_payload(ver, &payload)?,
+            )),
+            _ => Err(DecodeError::Invalid),
         }
     }
 }
@@ -33,36 +34,22 @@ pub struct PublicKey(pub [u8; 32]);
 
 impl PublicKey {
     pub fn to_string(&self) -> String {
-        encode(Version::PublicKeyEd25519, &self.0)
+        encode(version::PUBLIC_KEY_ED25519, &self.0)
     }
 
-    fn from_version_and_payload(ver: Version, payload: &[u8]) -> Result<Self, DecodeError> {
+    fn from_version_and_payload(ver: u8, payload: &[u8]) -> Result<Self, DecodeError> {
         match ver {
-            Version::PublicKeyEd25519 => match payload.try_into() {
+            version::PUBLIC_KEY_ED25519 => match payload.try_into() {
                 Ok(ed25519) => Ok(Self(ed25519)),
                 Err(_) => Err(DecodeError::Invalid),
             },
+            _ => Err(DecodeError::Invalid),
         }
     }
 
     pub fn from_string(s: &str) -> Result<Self, DecodeError> {
         let (ver, payload) = decode(s)?;
         Self::from_version_and_payload(ver, &payload)
-    }
-}
-
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
-#[repr(u8)]
-enum Version {
-    PublicKeyEd25519 = version::PUBLIC_KEY_ED25519,
-}
-
-impl Version {
-    fn try_from(b: u8) -> Result<Self, DecodeError> {
-        match b {
-            version::PUBLIC_KEY_ED25519 => Ok(Version::PublicKeyEd25519),
-            _ => Err(DecodeError::Invalid),
-        }
     }
 }
 
@@ -84,15 +71,15 @@ mod public_key_alg {
 // TODO: Could encode and decode, and the functions upstream that call them, be
 // const fn's?
 
-fn encode(v: Version, payload: &[u8]) -> String {
+fn encode(ver: u8, payload: &[u8]) -> String {
     let mut d: Vec<u8> = Vec::with_capacity(1 + payload.len() + 2);
-    d.push(v as u8);
+    d.push(ver);
     d.extend_from_slice(&payload);
     d.extend_from_slice(&checksum(&d));
     base32::encode(base32::Alphabet::RFC4648 { padding: false }, &d)
 }
 
-fn decode(s: &str) -> Result<(Version, Vec<u8>), DecodeError> {
+fn decode(s: &str) -> Result<(u8, Vec<u8>), DecodeError> {
     // TODO: Look at what other base32 implementations are available, because
     // this one allows for decoding of non-canonical base32 strings, and doesn't
     // come with helpful methods for validating the length is canonical.
@@ -105,7 +92,7 @@ fn decode(s: &str) -> Result<(Version, Vec<u8>), DecodeError> {
         if data.len() < 3 {
             return Err(DecodeError::Invalid);
         }
-        let ver = Version::try_from(data[0])?;
+        let ver = data[0];
         let (data_without_crc, crc_actual) = data.split_at(data.len() - 2);
         let crc_expect = checksum(&data_without_crc);
         if crc_actual != crc_expect {


### PR DESCRIPTION
### What

Remove the Version enum.

### Why

It's an internal type, and doesn't offer a whole lot, it just adds extra code. In the spirit of @tomerweller's simplifying of this package it seems better not to have.

### Known limitations

N/A
