### PR TITLE
Add complete job that succeeds if all others succeed

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,14 @@ env:
 
 jobs:
 
+  complete:
+    if: always()
+    needs: [fmt, build, test]
+    runs-on: ubuntu-latest
+    steps:
+    - if: contains(needs.*.result, 'failure')
+      run: exit 1
+
   fmt:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### What

Add complete job that succeeds or fails based on all others.

### Why

So that we can configure terraform/GitHub protected branches checks to follow one build, and then we can configure within this repo which builds are required for that job to succeed. It means we don't have to update terraform files every time we change the builds in this repo.

Related https://github.com/stellar/terraform/pull/804

### Known limitations

N/A
