### PR TITLE
Fix ci complete job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     needs: [fmt, build, test]
     runs-on: ubuntu-latest
     steps:
-    - if: contains(needs.*.result, 'failure')
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
       run: exit 1
 
   fmt:


### PR DESCRIPTION
### What
Change ci complete job so that it errors if a depended job is cancelled.

### Why
At the moment it only errors if the depended jobs fail, but if they are cancelled they won't have the failure status and the complete job will succeed.