### PR TITLE
Add Display impl for DecodeError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ proptest = "1.0.0"
 
 [dependencies]
 base32 = "0.4.0"
+thiserror = "1.0.36"

--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -1,10 +1,13 @@
 use std::str::FromStr;
 
+use thiserror::Error;
+
 use crate::crc::checksum;
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Error, Clone, PartialEq, Eq, Debug)]
 pub enum DecodeError {
     // TODO: Add meaningful errors for each problem that can occur.
+    #[error("the strkey is invalid")]
     Invalid,
 }
 


### PR DESCRIPTION
### What
Add Display impl for DecodeError.

### Why
It is required to use the error type with clap-rs.