### PR TITLE
Feat!:use standard conversion traits

### DIFF
--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -56,7 +56,10 @@ impl TryFrom<&[u8]> for StrkeyPublicKeyEd25519 {
     type Error = DecodeError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        value.try_into().map_err(|_| DecodeError::Invalid)
+        value
+            .try_into()
+            .map_err(|_| DecodeError::Invalid)
+            .map(|i| Self(i))
     }
 }
 impl TryFrom<Vec<u8>> for StrkeyPublicKeyEd25519 {
@@ -91,7 +94,10 @@ impl TryFrom<&[u8]> for StrkeyPrivateKeyEd25519 {
     type Error = DecodeError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        value.try_into().map_err(|_| DecodeError::Invalid)
+        value
+            .try_into()
+            .map_err(|_| DecodeError::Invalid)
+            .map(|i| Self(i))
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -20,19 +20,19 @@ fn test_valid_public_keys() {
 #[test]
 fn test_invalid_public_keys() {
     // Invalid length (Ed25519 should be 32 bytes, not 5).
-    let r = Strkey::from_str("GAAAAAAAACGC6");
+    let mut r = "GAAAAAAAACGC6".parse::<Strkey>();
     assert_eq!(r, Err(DecodeError::Invalid));
 
     // Invalid length (congruent to 1 mod 8).
-    let r = Strkey::from_str("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZA");
+    r = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZA".parse();
     assert_eq!(r, Err(DecodeError::Invalid));
 
     // Invalid length (base-32 decoding should yield 35 bytes, not 36).
-    let r = Strkey::from_str("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUACUSI");
+    r = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUACUSI".parse();
     assert_eq!(r, Err(DecodeError::Invalid));
 
     // Invalid algorithm (low 3 bits of version byte are 7).
-    let r = Strkey::from_str("G47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVP2I");
+    r = "G47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVP2I".parse();
     assert_eq!(r, Err(DecodeError::Invalid));
 }
 
@@ -64,7 +64,7 @@ proptest! {
 }
 
 fn assert_convert_roundtrip(s: &str, strkey: &Strkey) {
-    let strkey_result = Strkey::from_str(s).unwrap();
+    let strkey_result = s.parse().unwrap();
     assert_eq!(&strkey_result, strkey);
     let str_result = strkey.to_string();
     assert_eq!(s, str_result);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,6 @@
-use stellar_strkey::*;
+use std::str::FromStr;
+
+use stellar_strkey::{DecodeError, Strkey, StrkeyPrivateKeyEd25519, StrkeyPublicKeyEd25519};
 extern crate proptest;
 use proptest::prelude::*;
 
@@ -18,19 +20,19 @@ fn test_valid_public_keys() {
 #[test]
 fn test_invalid_public_keys() {
     // Invalid length (Ed25519 should be 32 bytes, not 5).
-    let r = Strkey::from_string("GAAAAAAAACGC6");
+    let r = Strkey::from_str("GAAAAAAAACGC6");
     assert_eq!(r, Err(DecodeError::Invalid));
 
     // Invalid length (congruent to 1 mod 8).
-    let r = Strkey::from_string("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZA");
+    let r = Strkey::from_str("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZA");
     assert_eq!(r, Err(DecodeError::Invalid));
 
     // Invalid length (base-32 decoding should yield 35 bytes, not 36).
-    let r = Strkey::from_string("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUACUSI");
+    let r = Strkey::from_str("GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUACUSI");
     assert_eq!(r, Err(DecodeError::Invalid));
 
     // Invalid algorithm (low 3 bits of version byte are 7).
-    let r = Strkey::from_string("G47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVP2I");
+    let r = Strkey::from_str("G47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVP2I");
     assert_eq!(r, Err(DecodeError::Invalid));
 }
 
@@ -49,8 +51,8 @@ fn test_valid_private_keys() {
 
 proptest! {
     #[test]
-    fn test_public_key_ed25519_from_string_doesnt_panic(data: String) {
-        let _ = Strkey::from_string(&data);
+    fn test_public_key_ed25519_from_str_doesnt_panic(data: String) {
+        let _ = Strkey::from_str(&data);
     }
 }
 
@@ -62,8 +64,8 @@ proptest! {
 }
 
 fn assert_convert_roundtrip(s: &str, strkey: &Strkey) {
-    let strkey_result = Strkey::from_string(&s).unwrap();
+    let strkey_result = Strkey::from_str(s).unwrap();
     assert_eq!(&strkey_result, strkey);
     let str_result = strkey.to_string();
-    assert_eq!(s, str_result)
+    assert_eq!(s, str_result);
 }


### PR DESCRIPTION
### What

Use the standard conversion traits.

### Why

This that will make the type more easy to deal with and be used in format strings. E.g. 

```rust

let key: Strkey = "...".parse().unwrap();
println!("My key: {key}");
```

### Known limitations

This is a breaking change for `from_payload` to `try_into`.
