### PR TITLE
Remove thiserror (extracted from #64)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 readme = "README.md"
 version = "0.0.10"
 edition = "2021"
-rust-version = "1.67.0"
+rust-version = "1.81.0"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,4 @@ proptest = "1.0.0"
 
 [dependencies]
 data-encoding = "2.6.0"
-thiserror = "1.0.36"
 clap = { version = "4.2.4", default-features = false, features = ["std", "derive", "usage", "help"], optional = true }

--- a/src/bin/stellar-strkey/decode.rs
+++ b/src/bin/stellar-strkey/decode.rs
@@ -3,11 +3,22 @@ use std::str::FromStr;
 use clap::Args;
 use stellar_strkey::DecodeError;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(Debug)]
 pub enum Error {
-    #[error("decoding {0:?}: {1}")]
     Decode(String, DecodeError),
 }
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, __formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            Error::Decode(s, inner) => {
+                __formatter.write_fmt(format_args!("decoding {s:?}: {inner}"))
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 #[derive(Args, Debug, Clone)]
 #[command()]

--- a/src/bin/stellar-strkey/decode.rs
+++ b/src/bin/stellar-strkey/decode.rs
@@ -9,10 +9,10 @@ pub enum Error {
 }
 
 impl core::fmt::Display for Error {
-    fn fmt(&self, __formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             Error::Decode(s, inner) => {
-                __formatter.write_fmt(format_args!("decoding {s:?}: {inner}"))
+                f.write_fmt(format_args!("decoding {s:?}: {inner}"))
             }
         }
     }

--- a/src/bin/stellar-strkey/decode.rs
+++ b/src/bin/stellar-strkey/decode.rs
@@ -11,9 +11,7 @@ pub enum Error {
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
-            Error::Decode(s, inner) => {
-                f.write_fmt(format_args!("decoding {s:?}: {inner}"))
-            }
+            Error::Decode(s, inner) => f.write_fmt(format_args!("decoding {s:?}: {inner}")),
         }
     }
 }

--- a/src/bin/stellar-strkey/decode.rs
+++ b/src/bin/stellar-strkey/decode.rs
@@ -16,7 +16,7 @@ impl core::fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 #[derive(Args, Debug, Clone)]
 #[command()]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,15 @@
-#[derive(thiserror::Error, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum DecodeError {
     // TODO: Add meaningful errors for each problem that can occur.
-    #[error("the strkey is invalid")]
     Invalid,
 }
+
+impl core::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            DecodeError::Invalid {} => f.write_str("the strkey is invalid"),
+        }
+    }
+}
+
+impl std::error::Error for DecodeError {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,4 +12,4 @@ impl core::fmt::Display for DecodeError {
     }
 }
 
-impl std::error::Error for DecodeError {}
+impl core::error::Error for DecodeError {}


### PR DESCRIPTION
### What

Remove the thiserror crate and replace with the same code that would be generated.

### Why

As @overcat pointed out in https://github.com/stellar/rs-stellar-strkey/pull/64#discussion_r1740030545, the thiserror crate does very little, and crates a dependence on std that we plan to remove in #64.

This change was authored by @overcat in #64, and has been extracted to commit separately to reduce the dep graph created by this crate.

### Known limitations

[TODO or N/A]
