### PR TITLE
Add serde traits to LiquidityPool and ClaimableBalance

### DIFF
--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -255,6 +255,10 @@ impl FromStr for Contract {
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
 pub struct LiquidityPool(pub [u8; 32]);
 
 impl Debug for LiquidityPool {
@@ -307,6 +311,10 @@ impl FromStr for LiquidityPool {
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
 pub enum ClaimableBalance {
     V0([u8; 32]),
 }


### PR DESCRIPTION
### What
Add SerializeDisplay and DeserializeFromStr traits to LiquidityPool and ClaimableBalance types when the serde feature is enabled.

### Why
Consistency with the other types in the crate that also derive these. The traits missing means the types can't be used directly in other types that derive to serde. This causes no immediate problem, I just noticed the inconsistency.