### PR TITLE
Make CLI embeddable in other CLIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.81.0"
 
 [features]
 default = []
-cli = ["dep:clap", "dep:serde", "dep:cfg_eval", "dep:serde_with", "serde_with/hex", "dep:serde_json"]
+cli = ["dep:clap", "dep:serde", "dep:cfg_eval", "dep:serde_with", "serde_with/hex", "dep:serde_json", "dep:thiserror"]
 serde = ["dep:serde_with"]
 
 [[bin]]
@@ -35,3 +35,4 @@ serde_with = { version = "3.11.0", optional = true, features = ["hex"] }
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = { version = "1", optional = true }
 cfg_eval = { version = "0.1.2", optional = true }
+thiserror = { version = "1.0", optional = true }

--- a/src/bin/stellar-strkey/main.rs
+++ b/src/bin/stellar-strkey/main.rs
@@ -4,6 +4,11 @@ use stellar_strkey::cli;
 
 fn main() {
     if let Err(e) = cli::run(env::args_os()) {
-        Error::raw(clap::error::ErrorKind::ValueValidation, e).exit()
+        match e {
+            cli::Error::Clap(e) => e.exit(),
+            cli::Error::Decode(_) | cli::Error::Encode(_) => {
+                Error::raw(clap::error::ErrorKind::ValueValidation, e).exit()
+            }
+        }
     }
 }

--- a/src/bin/stellar-strkey/main.rs
+++ b/src/bin/stellar-strkey/main.rs
@@ -1,54 +1,9 @@
-mod decode;
-mod encode;
-mod version;
-mod zero;
-
-use clap::{CommandFactory, Parser, Subcommand};
-use std::{error::Error, fmt::Debug};
-
-#[derive(Parser, Debug, Clone)]
-#[command(
-    author,
-    version,
-    about,
-    long_about = None,
-    disable_help_subcommand = true,
-    disable_version_flag = true,
-    disable_colored_help = true,
-    infer_subcommands = true,
-)]
-struct Root {
-    #[command(subcommand)]
-    cmd: Cmd,
-}
-
-#[derive(Subcommand, Debug, Clone)]
-enum Cmd {
-    /// Decode strkey
-    Decode(decode::Cmd),
-    /// Encode strkey
-    Encode(encode::Cmd),
-    /// Generate the zero strkey
-    Zero(zero::Cmd),
-    /// Print version information
-    Version,
-}
-
-fn run() -> Result<(), Box<dyn Error>> {
-    let root = Root::parse();
-    match root.cmd {
-        Cmd::Decode(c) => c.run()?,
-        Cmd::Encode(c) => c.run()?,
-        Cmd::Zero(c) => c.run(),
-        Cmd::Version => version::Cmd::run(),
-    }
-    Ok(())
-}
+use clap::Error;
+use std::env;
+use stellar_strkey::cli;
 
 fn main() {
-    if let Err(e) = run() {
-        Root::command()
-            .error(clap::error::ErrorKind::ValueValidation, e)
-            .exit()
+    if let Err(e) = cli::run(env::args_os()) {
+        Error::raw(clap::error::ErrorKind::ValueValidation, e).exit()
     }
 }

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
+use crate::{DecodeError, Strkey};
 use clap::Args;
-use crate::{Strkey, DecodeError};
 
 #[derive(Debug)]
 pub enum Error {
@@ -28,8 +28,8 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
-        let strkey = Strkey::from_str(&self.strkey)
-            .map_err(|e| Error::Decode(self.strkey.clone(), e))?;
+        let strkey =
+            Strkey::from_str(&self.strkey).map_err(|e| Error::Decode(self.strkey.clone(), e))?;
         let json = serde_json::to_string_pretty(&strkey).unwrap();
         println!("{json}");
         Ok(())

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use clap::Args;
-use stellar_strkey::DecodeError;
+use crate::{Strkey, DecodeError};
 
 #[derive(Debug)]
 pub enum Error {
@@ -28,7 +28,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
-        let strkey = stellar_strkey::Strkey::from_str(&self.strkey)
+        let strkey = Strkey::from_str(&self.strkey)
             .map_err(|e| Error::Decode(self.strkey.clone(), e))?;
         let json = serde_json::to_string_pretty(&strkey).unwrap();
         println!("{json}");

--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -27,8 +27,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
-        let strkey: Strkey =
-            serde_json::from_str(&self.json).map_err(Error::Json)?;
+        let strkey: Strkey = serde_json::from_str(&self.json).map_err(Error::Json)?;
         println!("{strkey}");
         Ok(())
     }

--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -1,5 +1,7 @@
 use clap::Args;
 
+use crate::Strkey;
+
 #[derive(Debug)]
 pub enum Error {
     Json(serde_json::Error),
@@ -25,7 +27,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
-        let strkey: stellar_strkey::Strkey =
+        let strkey: Strkey =
             serde_json::from_str(&self.json).map_err(Error::Json)?;
         println!("{strkey}");
         Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,7 +4,7 @@ pub mod version;
 pub mod zero;
 
 use clap::{Parser, Subcommand};
-use std::{error::Error, ffi::OsString, fmt::Debug, boxed::Box};
+use std::{boxed::Box, error::Error, ffi::OsString, fmt::Debug};
 
 #[derive(Parser, Debug, Clone)]
 #[command(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,66 @@
+pub mod decode;
+pub mod encode;
+pub mod version;
+pub mod zero;
+
+use clap::{Parser, Subcommand};
+use std::{error::Error, ffi::OsString, fmt::Debug, boxed::Box};
+
+#[derive(Parser, Debug, Clone)]
+#[command(
+    author,
+    version,
+    about,
+    long_about = None,
+    disable_help_subcommand = true,
+    disable_version_flag = true,
+    disable_colored_help = true,
+    infer_subcommands = true,
+)]
+pub struct Root {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+enum Cmd {
+    /// Decode strkey
+    Decode(decode::Cmd),
+    /// Encode strkey
+    Encode(encode::Cmd),
+    /// Generate the zero strkey
+    Zero(zero::Cmd),
+    /// Print version information
+    Version,
+}
+
+impl Root {
+    /// Run the CLIs root command.
+    ///
+    /// ## Errors
+    ///
+    /// If the root command is configured with state that is invalid.
+    pub fn run(&self) -> Result<(), Box<dyn Error>> {
+        match &self.cmd {
+            Cmd::Decode(c) => c.run()?,
+            Cmd::Encode(c) => c.run()?,
+            Cmd::Zero(c) => c.run(),
+            Cmd::Version => version::Cmd::run(),
+        }
+        Ok(())
+    }
+}
+
+/// Run the CLI with the given args.
+///
+/// ## Errors
+///
+/// If the input cannot be parsed.
+pub fn run<I, T>(args: I) -> Result<(), Box<dyn Error>>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let root = Root::try_parse_from(args)?;
+    root.run()
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,7 +4,7 @@ pub mod version;
 pub mod zero;
 
 use clap::{Parser, Subcommand};
-use std::{boxed::Box, error::Error, ffi::OsString, fmt::Debug};
+use std::{ffi::OsString, fmt::Debug};
 
 #[derive(Parser, Debug, Clone)]
 #[command(
@@ -40,7 +40,7 @@ impl Root {
     /// ## Errors
     ///
     /// If the root command is configured with state that is invalid.
-    pub fn run(&self) -> Result<(), Box<dyn Error>> {
+    pub fn run(&self) -> Result<(), Error> {
         match &self.cmd {
             Cmd::Decode(c) => c.run()?,
             Cmd::Encode(c) => c.run()?,
@@ -51,12 +51,22 @@ impl Root {
     }
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Clap(#[from] clap::Error),
+    #[error(transparent)]
+    Decode(#[from] decode::Error),
+    #[error(transparent)]
+    Encode(#[from] encode::Error),
+}
+
 /// Run the CLI with the given args.
 ///
 /// ## Errors
 ///
 /// If the input cannot be parsed.
-pub fn run<I, T>(args: I) -> Result<(), Box<dyn Error>>
+pub fn run<I, T>(args: I) -> Result<(), Error>
 where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -1,12 +1,14 @@
 use clap::Parser;
 
+use crate::VERSION;
+
 #[derive(Parser, Debug, Clone)]
 #[command()]
 pub struct Cmd;
 
 impl Cmd {
     pub fn run() {
-        let v = stellar_strkey::VERSION;
+        let v = VERSION;
         println!("stellar-strkey {} ({})", v.pkg, v.rev);
     }
 }

--- a/src/cli/zero.rs
+++ b/src/cli/zero.rs
@@ -1,5 +1,5 @@
 use clap::{Args, ValueEnum};
-use stellar_strkey::{
+use crate::{
     ed25519, ClaimableBalance, Contract, HashX, LiquidityPool, PreAuthTx, Strkey,
 };
 

--- a/src/cli/zero.rs
+++ b/src/cli/zero.rs
@@ -1,7 +1,5 @@
+use crate::{ed25519, ClaimableBalance, Contract, HashX, LiquidityPool, PreAuthTx, Strkey};
 use clap::{Args, ValueEnum};
-use crate::{
-    ed25519, ClaimableBalance, Contract, HashX, LiquidityPool, PreAuthTx, Strkey,
-};
 
 #[derive(Args, Debug, Clone)]
 #[command()]

--- a/src/cli/zero.rs
+++ b/src/cli/zero.rs
@@ -13,7 +13,7 @@ pub struct Cmd {
 }
 
 #[derive(Clone, Debug, ValueEnum)]
-#[clap(rename_all = "snake_case")]
+#[value(rename_all = "snake_case")]
 pub enum StrkeyType {
     PublicKeyEd25519,
     // PrivateKeyEd25519 is intentionally omitted to reduce the chance someone accidentally thinks

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "cli"), no_std)]
 extern crate alloc;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
@@ -21,3 +21,6 @@ mod version;
 
 pub use error::*;
 pub use strkey::*;
+
+#[cfg(feature = "cli")]
+pub mod cli;


### PR DESCRIPTION
### What
Move CLI from bin to lib directory, and make the CLI a light wrapper around the CLI library functionality.

### Why
Allows the CLI code to be embedded in other CLIs, like the stellar-cli. Follows the same pattern as the stellar-xdr CLI that is embedded in the stellar-cli.