### PR TITLE
Fix typo in crc module comment

### DIFF
--- a/src/crc.rs
+++ b/src/crc.rs
@@ -1,4 +1,4 @@
-// Mod crc implementated according to CCITT standards.
+// Mod crc implemented according to CCITT standards.
 //
 // Name                       : "XMODEM", also known as "ZMODEM", "CRC-16/ACORN"
 // Width                      : 16 bit


### PR DESCRIPTION
### What
Correct "implementated" to "implemented" in the crc module's header comment.

### Why
Fix a spelling error so the comment reads correctly.