### PR TITLE
Reject extra keys in Decoded<Strkey> deserializer

### DIFF
--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -250,6 +250,10 @@ mod strkey_decoded_serde_impl {
                         }
                     };
 
+                    if map.next_key::<de::IgnoredAny>()?.is_some() {
+                        return Err(de::Error::custom("expected exactly one variant key"));
+                    }
+
                     Ok(Decoded(strkey))
                 }
             }

--- a/tests/cli_json.rs
+++ b/tests/cli_json.rs
@@ -152,3 +152,19 @@ fn test_roundtrip_claimable_balance() {
     let Decoded(deserialized): Decoded<Strkey> = serde_json::from_str(&json).unwrap();
     assert_eq!(original, deserialized);
 }
+
+#[test]
+fn test_extra_variant_keys_rejected() {
+    let json = r#"{
+        "public_key_ed25519": "0000000000000000000000000000000000000000000000000000000000000000",
+        "contract": "0000000000000000000000000000000000000000000000000000000000000000"
+    }"#;
+    let err = match serde_json::from_str::<Decoded<Strkey>>(json) {
+        Ok(_) => panic!("expected error for JSON with extra variant keys"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().contains("expected exactly one variant key"),
+        "unexpected error message: {err}",
+    );
+}


### PR DESCRIPTION
### What

Make the `Decoded<Strkey>` `visit_map` deserializer (under the `serde-decoded` feature) check for additional map entries after consuming the first variant key/value pair. If any extra keys remain, deserialization now fails with a clear error: `expected exactly one variant key`.

### Why

The previous implementation only read the first key/value pair and returned `Ok` without consuming or rejecting the rest. When a user supplied a JSON object with additional keys (for example via the CLI `encode` command), `serde_json` would surface misleading errors suggesting invalid JSON (such as "trailing comma"), even though the JSON was syntactically correct. The actual requirement — that the object contain exactly one variant key — was obscured, making troubleshooting difficult.

### Example

**Before** (input with extra keys):

```json
{
  "public_key_ed25519": "0000000000000000000000000000000000000000000000000000000000000000",
  "contract": "0000000000000000000000000000000000000000000000000000000000000000"
}
```

Error: misleading `serde_json` message resembling a JSON syntax error.

**After:**

Error: `expected exactly one variant key`