### PR TITLE
Cap CLI encode JSON input at 10 KiB

### DIFF
--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -2,14 +2,25 @@ use clap::Args;
 
 use crate::{Decoded, Strkey};
 
+// Bound on the JSON input size. The largest legitimate Decoded<Strkey> JSON
+// (a pretty-printed signed_payload_ed25519 with a max 64-byte payload) is
+// under 300 bytes; 10 KiB allows generous formatting headroom while
+// preventing pathologically large hex fields from forcing intermediate
+// allocations during deserialization.
+const MAX_JSON_LEN: usize = 10 * 1024;
+
 #[derive(Debug)]
 pub enum Error {
+    InputTooLarge { len: usize, max: usize },
     Json(serde_json::Error),
 }
 
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
+            Error::InputTooLarge { len, max } => f.write_fmt(format_args!(
+                "json input too large: {len} bytes (max {max})"
+            )),
             Error::Json(e) => f.write_fmt(format_args!("{e}")),
         }
     }
@@ -27,6 +38,12 @@ pub struct Cmd {
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
+        if self.json.len() > MAX_JSON_LEN {
+            return Err(Error::InputTooLarge {
+                len: self.json.len(),
+                max: MAX_JSON_LEN,
+            });
+        }
         let Decoded(strkey): Decoded<Strkey> =
             serde_json::from_str(&self.json).map_err(Error::Json)?;
         println!("{strkey}");


### PR DESCRIPTION
### What
Reject inputs to the CLI `encode` command whose JSON exceeds 10 KiB before they are passed to `serde_json::from_str`. A new `Error::InputTooLarge { len, max }` variant carries the rejected size and the cap so users see exactly what hit the limit.

### Why
The largest legitimate `Decoded<Strkey>` JSON — a pretty-printed `signed_payload_ed25519` with a maximum 64-byte payload — is under 300 bytes. 10 KiB leaves generous formatting headroom while bounding the worst-case allocation the CLI can be coerced into making. The underlying library-side fix (a bounded hex-decode path) is intentionally out of scope for this PR.

### Example

The CLI accepts arbitrarily large JSON and forwards it to the deserializer, which allocates proportional to the hex payload before rejecting it.