### PR TITLE
Add crate-level documentation

### DIFF
--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -109,6 +109,7 @@ mod private_key_decoded_serde_impl {
     }
 }
 
+/// An ed25519 public key (`G...`).
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde",
@@ -208,6 +209,7 @@ mod public_key_decoded_serde_impl {
     }
 }
 
+/// A muxed ed25519 account (`M...`).
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,98 @@
+//! Encode and decode [Stellar strkeys] as defined by [SEP-23].
+//!
+//! Strkeys are the human-readable textual representation of identifiers used
+//! across the Stellar network — account IDs, signing keys, contract IDs,
+//! liquidity pool IDs, and others. Each strkey begins with a single ASCII
+//! letter that identifies its kind (`G`, `S`, `M`, `T`, `X`, `P`, `C`, `L`,
+//! `B`) and is encoded as base32 without padding. The binary form is a
+//! one-byte version, the type's payload, and a two-byte CRC16-XMODEM
+//! checksum, ensuring that mistyped strkeys are detected before they are
+//! used.
+//!
+//! This crate provides:
+//!
+//! - The [`Strkey`] enum, which can hold and round-trip any strkey kind.
+//! - Per-kind types in this module ([`PreAuthTx`], [`HashX`], [`Contract`],
+//!   [`LiquidityPool`], [`ClaimableBalance`]) and in [`ed25519`]
+//!   ([`ed25519::PublicKey`], [`ed25519::PrivateKey`],
+//!   [`ed25519::MuxedAccount`], [`ed25519::SignedPayload`]) for callers that
+//!   know the kind in advance.
+//! - [`Display`](core::fmt::Display) and [`FromStr`](core::str::FromStr)
+//!   implementations for every kind, plus inherent `to_string` /
+//!   `from_string` / `from_slice` methods.
+//!
+//! # Strkey kinds
+//!
+//! | Prefix | Kind                                                                  | Payload bytes |
+//! |--------|-----------------------------------------------------------------------|---------------|
+//! | `G`    | [`Strkey::PublicKeyEd25519`] / [`ed25519::PublicKey`]                  |            32 |
+//! | `S`    | [`Strkey::PrivateKeyEd25519`] / [`ed25519::PrivateKey`]                |            32 |
+//! | `M`    | [`Strkey::MuxedAccountEd25519`] / [`ed25519::MuxedAccount`]            |            40 |
+//! | `T`    | [`Strkey::PreAuthTx`] / [`PreAuthTx`]                                  |            32 |
+//! | `X`    | [`Strkey::HashX`] / [`HashX`]                                          |            32 |
+//! | `P`    | [`Strkey::SignedPayloadEd25519`] / [`ed25519::SignedPayload`]          |        40–100 |
+//! | `C`    | [`Strkey::Contract`] / [`Contract`]                                    |            32 |
+//! | `L`    | [`Strkey::LiquidityPool`] / [`LiquidityPool`]                          |            32 |
+//! | `B`    | [`Strkey::ClaimableBalance`] / [`ClaimableBalance`]                    |            33 |
+//!
+//! # Examples
+//!
+//! Parse any strkey when the kind isn't known up front:
+//!
+//! ```
+//! use stellar_strkey::Strkey;
+//!
+//! let s = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+//! let strkey: Strkey = s.parse().unwrap();
+//! assert!(matches!(strkey, Strkey::PublicKeyEd25519(_)));
+//! ```
+//!
+//! Parse a specific kind and reject anything else:
+//!
+//! ```
+//! use stellar_strkey::Contract;
+//!
+//! let s = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+//! let contract: Contract = s.parse().unwrap();
+//! assert_eq!(contract.0, [0u8; 32]);
+//! ```
+//!
+//! Construct a strkey from raw bytes and render it:
+//!
+//! ```
+//! use stellar_strkey::ed25519::PublicKey;
+//!
+//! let key = PublicKey([0u8; 32]);
+//! assert_eq!(
+//!     format!("{key}"),
+//!     "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+//! );
+//! ```
+//!
+//! # `no_std`
+//!
+//! With default features the crate is `no_std` and does not depend on
+//! `alloc`. Encoding uses fixed-capacity buffers from the `heapless` crate,
+//! so each kind's `to_string` returns a `heapless::String` sized to the
+//! maximum length for that kind.
+//!
+//! # Cargo features
+//!
+//! - `serde` — derives [`Serialize`]/[`Deserialize`] that round-trip strkeys
+//!   as their textual form.
+//! - `serde-decoded` — adds a `Decoded<T>` wrapper that serializes a strkey
+//!   as a structured JSON object with hex-encoded byte fields, which is
+//!   useful for tooling that wants to inspect the underlying bytes. Requires
+//!   `alloc` and implies `serde`.
+//! - `cli` — builds the `stellar-strkey` binary for encoding and decoding
+//!   strkeys from the command line. Requires `alloc`. Not intended for
+//!   enabling with the library.
+//!
+//! [Stellar strkeys]: https://developers.stellar.org/docs/learn/glossary#strkey
+//! [SEP-23]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md
+//! [`Serialize`]: https://docs.rs/serde/latest/serde/trait.Serialize.html
+//! [`Deserialize`]: https://docs.rs/serde/latest/serde/trait.Deserialize.html
+
 #![cfg_attr(not(feature = "cli"), no_std)]
 
 #[cfg(feature = "serde-decoded")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //!
 //! let key = PublicKey([0u8; 32]);
 //! assert_eq!(
-//!     format!("{key}"),
+//!     key.to_string().as_str(),
 //!     "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
 //! );
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,8 +85,8 @@
 //!   useful for tooling that wants to inspect the underlying bytes. Requires
 //!   `alloc` and implies `serde`.
 //! - `cli` — builds the `stellar-strkey` binary for encoding and decoding
-//!   strkeys from the command line. Requires `alloc`. Not intended for
-//!   enabling with the library.
+//!   strkeys from the command line. Requires `std` (disables `no_std` for
+//!   the crate). Not intended for enabling with the library.
 //!
 //! [Stellar strkeys]: https://developers.stellar.org/docs/learn/glossary#strkey
 //! [SEP-23]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md

--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -263,6 +263,7 @@ mod strkey_decoded_serde_impl {
     }
 }
 
+/// A pre-authorized transaction signer (`T...`).
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde",
@@ -359,6 +360,7 @@ mod pre_auth_tx_decoded_serde_impl {
     }
 }
 
+/// A hash-x signer (`X...`).
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde",
@@ -455,6 +457,7 @@ mod hash_x_decoded_serde_impl {
     }
 }
 
+/// A contract identifier (`C...`).
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde",
@@ -551,6 +554,7 @@ mod contract_decoded_serde_impl {
     }
 }
 
+/// A liquidity pool identifier (`L...`).
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde",
@@ -647,6 +651,7 @@ mod liquidity_pool_decoded_serde_impl {
     }
 }
 
+/// A claimable balance identifier (`B...`).
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde",


### PR DESCRIPTION
### What

Add a `//!` module-level doc comment to `src/lib.rs` covering:

- What strkeys are and their grounding in [SEP-23](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md).
- The on-the-wire shape: 1-byte version, payload, 2-byte CRC16-XMODEM checksum, base32 no-pad.
- A table mapping each prefix letter (`G`, `S`, `M`, `T`, `X`, `P`, `C`, `L`, `B`) to the corresponding `Strkey` variant and dedicated type, with payload sizes.
- Three runnable, doc-tested examples: parse any strkey, parse a specific kind, and render a kind from raw bytes.
- `no_std` semantics, including the `heapless::String` return type from inherent `to_string` methods.
- The `serde`, `serde-decoded`, and `cli` Cargo features and what each enables.

### Why

The crate has no rustdoc landing page on docs.rs — readers arriving from crates.io or docs.rs see only the symbol list with no orientation about what strkeys are, how the encoding works, which type to use for which prefix, or which features to turn on. The README covers some of this but isn't surfaced in the rendered API docs. A crate-level doc comment fixes that without duplicating the README verbatim, and the doctests guard the examples against drift.

### Known limitations

N/A