### PR TITLE
Warn when CLI outputs private keys

### DIFF
--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -27,10 +27,10 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(&self, quiet: bool) -> Result<(), Error> {
+    pub fn run(&self, opts: &super::RunOpts) -> Result<(), Error> {
         let strkey =
             Strkey::from_str(&self.strkey).map_err(|e| Error::Decode(self.strkey.clone(), e))?;
-        if !quiet {
+        if !opts.quiet {
             super::warn_if_private(&strkey);
         }
         let json = serde_json::to_string_pretty(&Decoded(&strkey)).unwrap();

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -24,16 +24,17 @@ pub struct Cmd {
     /// Strkey to decode
     #[arg()]
     strkey: String,
+    /// Suppress stderr log and warning output
+    #[arg(long, short = 'q')]
+    quiet: bool,
 }
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
         let strkey =
             Strkey::from_str(&self.strkey).map_err(|e| Error::Decode(self.strkey.clone(), e))?;
-        if matches!(strkey, Strkey::PrivateKeyEd25519(_)) {
-            eprintln!(
-                "\u{26a0}\u{fe0f}  Warning: output contains a private key with secret material. Handle with care."
-            );
+        if !self.quiet {
+            super::warn_if_private(&strkey);
         }
         let json = serde_json::to_string_pretty(&Decoded(&strkey)).unwrap();
         println!("{json}");

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -24,16 +24,13 @@ pub struct Cmd {
     /// Strkey to decode
     #[arg()]
     strkey: String,
-    /// Suppress stderr log and warning output
-    #[arg(long, short = 'q')]
-    quiet: bool,
 }
 
 impl Cmd {
-    pub fn run(&self) -> Result<(), Error> {
+    pub fn run(&self, quiet: bool) -> Result<(), Error> {
         let strkey =
             Strkey::from_str(&self.strkey).map_err(|e| Error::Decode(self.strkey.clone(), e))?;
-        if !self.quiet {
+        if !quiet {
             super::warn_if_private(&strkey);
         }
         let json = serde_json::to_string_pretty(&Decoded(&strkey)).unwrap();

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -30,6 +30,11 @@ impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
         let strkey =
             Strkey::from_str(&self.strkey).map_err(|e| Error::Decode(self.strkey.clone(), e))?;
+        if matches!(strkey, Strkey::PrivateKeyEd25519(_)) {
+            eprintln!(
+                "\u{26a0}\u{fe0f}  Warning: output contains a private key with secret material. Handle with care."
+            );
+        }
         let json = serde_json::to_string_pretty(&Decoded(&strkey)).unwrap();
         println!("{json}");
         Ok(())

--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -37,7 +37,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(&self, quiet: bool) -> Result<(), Error> {
+    pub fn run(&self, opts: &super::RunOpts) -> Result<(), Error> {
         if self.json.len() > MAX_JSON_LEN {
             return Err(Error::InputTooLarge {
                 len: self.json.len(),
@@ -46,7 +46,7 @@ impl Cmd {
         }
         let Decoded(strkey): Decoded<Strkey> =
             serde_json::from_str(&self.json).map_err(Error::Json)?;
-        if !quiet {
+        if !opts.quiet {
             super::warn_if_private(&strkey);
         }
         println!("{strkey}");

--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -34,13 +34,10 @@ pub struct Cmd {
     /// JSON for Strkey to encode
     #[arg()]
     json: String,
-    /// Suppress stderr log and warning output
-    #[arg(long, short = 'q')]
-    quiet: bool,
 }
 
 impl Cmd {
-    pub fn run(&self) -> Result<(), Error> {
+    pub fn run(&self, quiet: bool) -> Result<(), Error> {
         if self.json.len() > MAX_JSON_LEN {
             return Err(Error::InputTooLarge {
                 len: self.json.len(),
@@ -49,7 +46,7 @@ impl Cmd {
         }
         let Decoded(strkey): Decoded<Strkey> =
             serde_json::from_str(&self.json).map_err(Error::Json)?;
-        if !self.quiet {
+        if !quiet {
             super::warn_if_private(&strkey);
         }
         println!("{strkey}");

--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -34,6 +34,9 @@ pub struct Cmd {
     /// JSON for Strkey to encode
     #[arg()]
     json: String,
+    /// Suppress stderr log and warning output
+    #[arg(long, short = 'q')]
+    quiet: bool,
 }
 
 impl Cmd {
@@ -46,10 +49,8 @@ impl Cmd {
         }
         let Decoded(strkey): Decoded<Strkey> =
             serde_json::from_str(&self.json).map_err(Error::Json)?;
-        if matches!(strkey, Strkey::PrivateKeyEd25519(_)) {
-            eprintln!(
-                "\u{26a0}\u{fe0f}  Warning: output contains a private key with secret material. Handle with care."
-            );
+        if !self.quiet {
+            super::warn_if_private(&strkey);
         }
         println!("{strkey}");
         Ok(())

--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -46,6 +46,11 @@ impl Cmd {
         }
         let Decoded(strkey): Decoded<Strkey> =
             serde_json::from_str(&self.json).map_err(Error::Json)?;
+        if matches!(strkey, Strkey::PrivateKeyEd25519(_)) {
+            eprintln!(
+                "\u{26a0}\u{fe0f}  Warning: output contains a private key with secret material. Handle with care."
+            );
+        }
         println!("{strkey}");
         Ok(())
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -39,6 +39,12 @@ enum Cmd {
     Version,
 }
 
+/// Runtime options sourced from global flags on [`Root`] and threaded to each
+/// subcommand's `run`.
+pub struct RunOpts {
+    pub quiet: bool,
+}
+
 impl Root {
     /// Run the CLIs root command.
     ///
@@ -46,9 +52,10 @@ impl Root {
     ///
     /// If the root command is configured with state that is invalid.
     pub fn run(&self) -> Result<(), Error> {
+        let opts = RunOpts { quiet: self.quiet };
         match &self.cmd {
-            Cmd::Decode(c) => c.run(self.quiet)?,
-            Cmd::Encode(c) => c.run(self.quiet)?,
+            Cmd::Decode(c) => c.run(&opts)?,
+            Cmd::Encode(c) => c.run(&opts)?,
             Cmd::Zero(c) => c.run(),
             Cmd::Version => version::Cmd::run(),
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -86,7 +86,7 @@ where
 pub(crate) fn warn_if_private(strkey: &Strkey) {
     if matches!(strkey, Strkey::PrivateKeyEd25519(_)) {
         eprintln!(
-            "⚠️\u{fe0f}  Warning: output contains a private key with secret material. Handle with care."
+            "⚠️  Warning: output contains a private key with secret material. Handle with care."
         );
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,8 @@ pub mod zero;
 use clap::{Parser, Subcommand};
 use std::{ffi::OsString, fmt::Debug};
 
+use crate::Strkey;
+
 #[derive(Parser, Debug, Clone)]
 #[command(
     author,
@@ -73,4 +75,15 @@ where
 {
     let root = Root::try_parse_from(args)?;
     root.run()
+}
+
+/// Emit a stderr warning when a `Strkey` bound for stdout contains secret
+/// material. Centralizes the invariant that every CLI path producing a
+/// `Strkey` for the user must screen it first.
+pub(crate) fn warn_if_private(strkey: &Strkey) {
+    if matches!(strkey, Strkey::PrivateKeyEd25519(_)) {
+        eprintln!(
+            "⚠️\u{fe0f}  Warning: output contains a private key with secret material. Handle with care."
+        );
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -41,8 +41,22 @@ enum Cmd {
 
 /// Runtime options sourced from global flags on [`Root`] and threaded to each
 /// subcommand's `run`.
+///
+/// Marked `#[non_exhaustive]` so adding fields is not a breaking change;
+/// external callers construct via [`RunOpts::default`] and the chainable
+/// setters (e.g. `RunOpts::default().quiet(true)`).
+#[non_exhaustive]
+#[derive(Default)]
 pub struct RunOpts {
     pub quiet: bool,
+}
+
+impl RunOpts {
+    #[must_use]
+    pub fn quiet(mut self, quiet: bool) -> Self {
+        self.quiet = quiet;
+        self
+    }
 }
 
 impl Root {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,6 +22,9 @@ use crate::Strkey;
 pub struct Root {
     #[command(subcommand)]
     cmd: Cmd,
+    /// Suppress stderr log and warning output
+    #[arg(long, short = 'q', global = true)]
+    quiet: bool,
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -44,8 +47,8 @@ impl Root {
     /// If the root command is configured with state that is invalid.
     pub fn run(&self) -> Result<(), Error> {
         match &self.cmd {
-            Cmd::Decode(c) => c.run()?,
-            Cmd::Encode(c) => c.run()?,
+            Cmd::Decode(c) => c.run(self.quiet)?,
+            Cmd::Encode(c) => c.run(self.quiet)?,
             Cmd::Zero(c) => c.run(),
             Cmd::Version => version::Cmd::run(),
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -41,22 +41,9 @@ enum Cmd {
 
 /// Runtime options sourced from global flags on [`Root`] and threaded to each
 /// subcommand's `run`.
-///
-/// Marked `#[non_exhaustive]` so adding fields is not a breaking change;
-/// external callers construct via [`RunOpts::default`] and the chainable
-/// setters (e.g. `RunOpts::default().quiet(true)`).
-#[non_exhaustive]
 #[derive(Default)]
 pub struct RunOpts {
     pub quiet: bool,
-}
-
-impl RunOpts {
-    #[must_use]
-    pub fn quiet(mut self, quiet: bool) -> Self {
-        self.quiet = quiet;
-        self
-    }
 }
 
 impl Root {


### PR DESCRIPTION
### What
Print a stderr warning from the `encode` and `decode` CLI commands when the output contains a private key.

### Why
This CLI is used for debugging, but there's nothing stopping someone from using it for scripting and other purposes and it can be helpful to alert the user that they're handling secret material if it isn't immediately obvious at a glance or missed in passing.