### PR TITLE
Support stdin for encode and decode CLI commands

### DIFF
--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -4,9 +4,15 @@ use std::str::FromStr;
 use crate::{DecodeError, Decoded, Strkey};
 use clap::Args;
 
+// Bound on the strkey input size. The longest legitimate strkey is a
+// signed_payload_ed25519 with a 64-byte payload, encoded to 165 base32
+// characters; 256 allows headroom and prevents unbounded reads from stdin.
+const MAX_STRKEY_LEN: usize = 256;
+
 #[derive(Debug)]
 pub enum Error {
     Decode(String, DecodeError),
+    InputTooLarge { len: usize, max: usize },
     Io(std::io::Error),
 }
 
@@ -14,6 +20,9 @@ impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             Error::Decode(s, inner) => f.write_fmt(format_args!("decoding {s:?}: {inner}")),
+            Error::InputTooLarge { len, max } => f.write_fmt(format_args!(
+                "strkey input too large: {len} bytes (max {max})"
+            )),
             Error::Io(e) => f.write_fmt(format_args!("reading stdin: {e}")),
         }
     }
@@ -26,20 +35,32 @@ impl core::error::Error for Error {}
 pub struct Cmd {
     /// Strkey to decode (reads from stdin if not provided)
     #[arg()]
-    strkey: Option<String>,
+    pub(super) strkey: Option<String>,
 }
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
+        let buf;
         let input = match &self.strkey {
-            Some(s) => s.clone(),
+            Some(s) => s.trim(),
             None => {
                 let mut s = String::new();
-                std::io::stdin().read_to_string(&mut s).map_err(Error::Io)?;
-                s.trim().to_string()
+                std::io::stdin()
+                    .lock()
+                    .take(MAX_STRKEY_LEN as u64 + 1)
+                    .read_to_string(&mut s)
+                    .map_err(Error::Io)?;
+                if s.len() > MAX_STRKEY_LEN {
+                    return Err(Error::InputTooLarge {
+                        len: s.len(),
+                        max: MAX_STRKEY_LEN,
+                    });
+                }
+                buf = s;
+                buf.trim()
             }
         };
-        let strkey = Strkey::from_str(&input).map_err(|e| Error::Decode(input.clone(), e))?;
+        let strkey = Strkey::from_str(input).map_err(|e| Error::Decode(input.to_string(), e))?;
         let json = serde_json::to_string_pretty(&Decoded(&strkey)).unwrap();
         println!("{json}");
         Ok(())

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -7,7 +7,6 @@ use clap::Args;
 #[derive(Debug)]
 pub enum Error {
     Decode(String, DecodeError),
-    InputTooLarge { len: usize, max: usize },
     Io(std::io::Error),
     NoInput,
 }
@@ -16,9 +15,6 @@ impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             Error::Decode(s, inner) => f.write_fmt(format_args!("decoding {s:?}: {inner}")),
-            Error::InputTooLarge { len, max } => f.write_fmt(format_args!(
-                "strkey input too large: {len} bytes (max {max})"
-            )),
             Error::Io(e) => f.write_fmt(format_args!("reading stdin: {e}")),
             Error::NoInput => {
                 f.write_str("no input: provide a positional argument or pipe input to stdin")
@@ -41,30 +37,20 @@ impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
         let buf;
         let input = match &self.strkey {
-            Some(s) => s.trim(),
+            Some(s) => s.as_str(),
             None => {
                 let stdin = std::io::stdin();
                 if stdin.is_terminal() {
                     return Err(Error::NoInput);
                 }
-                // Read with a small amount of headroom over the longest valid
-                // strkey to accommodate trailing whitespace from pipes.
-                let cap = Strkey::MAX_ENCODED_LEN + 16;
                 let mut s = String::new();
                 stdin
                     .lock()
-                    .take(cap as u64 + 1)
+                    .take(Strkey::MAX_ENCODED_LEN as u64 + 1)
                     .read_to_string(&mut s)
                     .map_err(Error::Io)?;
                 buf = s;
-                let trimmed = buf.trim();
-                if trimmed.len() > Strkey::MAX_ENCODED_LEN {
-                    return Err(Error::InputTooLarge {
-                        len: trimmed.len(),
-                        max: Strkey::MAX_ENCODED_LEN,
-                    });
-                }
-                trimmed
+                buf.trim()
             }
         };
         let strkey = Strkey::from_str(input).map_err(|e| Error::Decode(input.to_string(), e))?;

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -7,6 +7,7 @@ use clap::Args;
 #[derive(Debug)]
 pub enum Error {
     Decode(String, DecodeError),
+    InputTooLarge { len: usize, max: usize },
     Io(std::io::Error),
     NoInput,
 }
@@ -15,6 +16,9 @@ impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             Error::Decode(s, inner) => f.write_fmt(format_args!("decoding {s:?}: {inner}")),
+            Error::InputTooLarge { len, max } => f.write_fmt(format_args!(
+                "strkey input too large: {len} bytes (max {max})"
+            )),
             Error::Io(e) => f.write_fmt(format_args!("reading stdin: {e}")),
             Error::NoInput => {
                 f.write_str("no input: provide a positional argument or pipe input to stdin")
@@ -43,12 +47,20 @@ impl Cmd {
                 if stdin.is_terminal() {
                     return Err(Error::NoInput);
                 }
+                // Allow some headroom over the longest valid strkey so that
+                // common trailing whitespace (e.g. \n, \r\n) is accepted.
+                // Anything beyond that is rejected outright rather than
+                // silently truncated.
+                let max = Strkey::MAX_ENCODED_LEN + 16;
                 let mut s = String::new();
                 stdin
                     .lock()
-                    .take(Strkey::MAX_ENCODED_LEN as u64 + 1)
+                    .take(max as u64 + 1)
                     .read_to_string(&mut s)
                     .map_err(Error::Io)?;
+                if s.len() > max {
+                    return Err(Error::InputTooLarge { len: s.len(), max });
+                }
                 buf = s;
                 buf.trim()
             }

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -1,19 +1,15 @@
-use std::io::Read;
+use std::io::{IsTerminal, Read};
 use std::str::FromStr;
 
 use crate::{DecodeError, Decoded, Strkey};
 use clap::Args;
-
-// Bound on the strkey input size. The longest legitimate strkey is a
-// signed_payload_ed25519 with a 64-byte payload, encoded to 165 base32
-// characters; 256 allows headroom and prevents unbounded reads from stdin.
-const MAX_STRKEY_LEN: usize = 256;
 
 #[derive(Debug)]
 pub enum Error {
     Decode(String, DecodeError),
     InputTooLarge { len: usize, max: usize },
     Io(std::io::Error),
+    NoInput,
 }
 
 impl core::fmt::Display for Error {
@@ -24,6 +20,9 @@ impl core::fmt::Display for Error {
                 "strkey input too large: {len} bytes (max {max})"
             )),
             Error::Io(e) => f.write_fmt(format_args!("reading stdin: {e}")),
+            Error::NoInput => {
+                f.write_str("no input: provide a positional argument or pipe input to stdin")
+            }
         }
     }
 }
@@ -35,7 +34,7 @@ impl core::error::Error for Error {}
 pub struct Cmd {
     /// Strkey to decode (reads from stdin if not provided)
     #[arg()]
-    pub(super) strkey: Option<String>,
+    strkey: Option<String>,
 }
 
 impl Cmd {
@@ -44,20 +43,28 @@ impl Cmd {
         let input = match &self.strkey {
             Some(s) => s.trim(),
             None => {
+                let stdin = std::io::stdin();
+                if stdin.is_terminal() {
+                    return Err(Error::NoInput);
+                }
+                // Read with a small amount of headroom over the longest valid
+                // strkey to accommodate trailing whitespace from pipes.
+                let cap = Strkey::MAX_ENCODED_LEN + 16;
                 let mut s = String::new();
-                std::io::stdin()
+                stdin
                     .lock()
-                    .take(MAX_STRKEY_LEN as u64 + 1)
+                    .take(cap as u64 + 1)
                     .read_to_string(&mut s)
                     .map_err(Error::Io)?;
-                if s.len() > MAX_STRKEY_LEN {
+                buf = s;
+                let trimmed = buf.trim();
+                if trimmed.len() > Strkey::MAX_ENCODED_LEN {
                     return Err(Error::InputTooLarge {
-                        len: s.len(),
-                        max: MAX_STRKEY_LEN,
+                        len: trimmed.len(),
+                        max: Strkey::MAX_ENCODED_LEN,
                     });
                 }
-                buf = s;
-                buf.trim()
+                trimmed
             }
         };
         let strkey = Strkey::from_str(input).map_err(|e| Error::Decode(input.to_string(), e))?;

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -41,7 +41,7 @@ impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
         let buf;
         let input = match &self.strkey {
-            Some(s) => s.as_str(),
+            Some(s) => s.trim(),
             None => {
                 let stdin = std::io::stdin();
                 if stdin.is_terminal() {

--- a/src/cli/decode.rs
+++ b/src/cli/decode.rs
@@ -1,3 +1,4 @@
+use std::io::Read;
 use std::str::FromStr;
 
 use crate::{DecodeError, Decoded, Strkey};
@@ -6,12 +7,14 @@ use clap::Args;
 #[derive(Debug)]
 pub enum Error {
     Decode(String, DecodeError),
+    Io(std::io::Error),
 }
 
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             Error::Decode(s, inner) => f.write_fmt(format_args!("decoding {s:?}: {inner}")),
+            Error::Io(e) => f.write_fmt(format_args!("reading stdin: {e}")),
         }
     }
 }
@@ -21,15 +24,22 @@ impl core::error::Error for Error {}
 #[derive(Args, Debug, Clone)]
 #[command()]
 pub struct Cmd {
-    /// Strkey to decode
+    /// Strkey to decode (reads from stdin if not provided)
     #[arg()]
-    strkey: String,
+    strkey: Option<String>,
 }
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
-        let strkey =
-            Strkey::from_str(&self.strkey).map_err(|e| Error::Decode(self.strkey.clone(), e))?;
+        let input = match &self.strkey {
+            Some(s) => s.clone(),
+            None => {
+                let mut s = String::new();
+                std::io::stdin().read_to_string(&mut s).map_err(Error::Io)?;
+                s.trim().to_string()
+            }
+        };
+        let strkey = Strkey::from_str(&input).map_err(|e| Error::Decode(input.clone(), e))?;
         let json = serde_json::to_string_pretty(&Decoded(&strkey)).unwrap();
         println!("{json}");
         Ok(())

--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::{IsTerminal, Read};
 
 use clap::Args;
 
@@ -16,6 +16,7 @@ pub enum Error {
     InputTooLarge { len: usize, max: usize },
     Json(serde_json::Error),
     Io(std::io::Error),
+    NoInput,
 }
 
 impl core::fmt::Display for Error {
@@ -26,6 +27,9 @@ impl core::fmt::Display for Error {
             )),
             Error::Json(e) => f.write_fmt(format_args!("{e}")),
             Error::Io(e) => f.write_fmt(format_args!("reading stdin: {e}")),
+            Error::NoInput => {
+                f.write_str("no input: provide a positional argument or pipe input to stdin")
+            }
         }
     }
 }
@@ -37,7 +41,7 @@ impl core::error::Error for Error {}
 pub struct Cmd {
     /// JSON for Strkey to encode (reads from stdin if not provided)
     #[arg()]
-    pub(super) json: Option<String>,
+    json: Option<String>,
 }
 
 impl Cmd {
@@ -46,8 +50,12 @@ impl Cmd {
         let input = match &self.json {
             Some(s) => s.as_str(),
             None => {
+                let stdin = std::io::stdin();
+                if stdin.is_terminal() {
+                    return Err(Error::NoInput);
+                }
                 let mut s = String::new();
-                std::io::stdin()
+                stdin
                     .lock()
                     .take(MAX_JSON_LEN as u64 + 1)
                     .read_to_string(&mut s)

--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -37,20 +37,23 @@ impl core::error::Error for Error {}
 pub struct Cmd {
     /// JSON for Strkey to encode (reads from stdin if not provided)
     #[arg()]
-    json: Option<String>,
+    pub(super) json: Option<String>,
 }
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
+        let buf;
         let input = match &self.json {
-            Some(s) => s.clone(),
+            Some(s) => s.as_str(),
             None => {
                 let mut s = String::new();
                 std::io::stdin()
+                    .lock()
                     .take(MAX_JSON_LEN as u64 + 1)
                     .read_to_string(&mut s)
                     .map_err(Error::Io)?;
-                s
+                buf = s;
+                buf.as_str()
             }
         };
         if input.len() > MAX_JSON_LEN {
@@ -59,7 +62,7 @@ impl Cmd {
                 max: MAX_JSON_LEN,
             });
         }
-        let Decoded(strkey): Decoded<Strkey> = serde_json::from_str(&input).map_err(Error::Json)?;
+        let Decoded(strkey): Decoded<Strkey> = serde_json::from_str(input).map_err(Error::Json)?;
         println!("{strkey}");
         Ok(())
     }

--- a/src/cli/encode.rs
+++ b/src/cli/encode.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+
 use clap::Args;
 
 use crate::{Decoded, Strkey};
@@ -13,6 +15,7 @@ const MAX_JSON_LEN: usize = 10 * 1024;
 pub enum Error {
     InputTooLarge { len: usize, max: usize },
     Json(serde_json::Error),
+    Io(std::io::Error),
 }
 
 impl core::fmt::Display for Error {
@@ -22,6 +25,7 @@ impl core::fmt::Display for Error {
                 "json input too large: {len} bytes (max {max})"
             )),
             Error::Json(e) => f.write_fmt(format_args!("{e}")),
+            Error::Io(e) => f.write_fmt(format_args!("reading stdin: {e}")),
         }
     }
 }
@@ -31,21 +35,31 @@ impl core::error::Error for Error {}
 #[derive(Args, Debug, Clone)]
 #[command()]
 pub struct Cmd {
-    /// JSON for Strkey to encode
+    /// JSON for Strkey to encode (reads from stdin if not provided)
     #[arg()]
-    json: String,
+    json: Option<String>,
 }
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
-        if self.json.len() > MAX_JSON_LEN {
+        let input = match &self.json {
+            Some(s) => s.clone(),
+            None => {
+                let mut s = String::new();
+                std::io::stdin()
+                    .take(MAX_JSON_LEN as u64 + 1)
+                    .read_to_string(&mut s)
+                    .map_err(Error::Io)?;
+                s
+            }
+        };
+        if input.len() > MAX_JSON_LEN {
             return Err(Error::InputTooLarge {
-                len: self.json.len(),
+                len: input.len(),
                 max: MAX_JSON_LEN,
             });
         }
-        let Decoded(strkey): Decoded<Strkey> =
-            serde_json::from_str(&self.json).map_err(Error::Json)?;
+        let Decoded(strkey): Decoded<Strkey> = serde_json::from_str(&input).map_err(Error::Json)?;
         println!("{strkey}");
         Ok(())
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,7 +3,8 @@ pub mod encode;
 pub mod version;
 pub mod zero;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use std::io::IsTerminal;
 use std::{ffi::OsString, fmt::Debug};
 
 #[derive(Parser, Debug, Clone)]
@@ -25,8 +26,14 @@ pub struct Root {
 #[derive(Subcommand, Debug, Clone)]
 enum Cmd {
     /// Decode strkey
+    ///
+    /// Reads the strkey from the positional argument, or from stdin if no
+    /// argument is provided.
     Decode(decode::Cmd),
     /// Encode strkey
+    ///
+    /// Reads the JSON from the positional argument, or from stdin if no
+    /// argument is provided.
     Encode(encode::Cmd),
     /// Generate the zero strkey
     Zero(zero::Cmd),
@@ -42,12 +49,25 @@ impl Root {
     /// If the root command is configured with state that is invalid.
     pub fn run(&self) -> Result<(), Error> {
         match &self.cmd {
+            Cmd::Decode(c) if c.strkey.is_none() && std::io::stdin().is_terminal() => {
+                print_subcommand_help("decode");
+            }
+            Cmd::Encode(c) if c.json.is_none() && std::io::stdin().is_terminal() => {
+                print_subcommand_help("encode");
+            }
             Cmd::Decode(c) => c.run()?,
             Cmd::Encode(c) => c.run()?,
             Cmd::Zero(c) => c.run(),
             Cmd::Version => version::Cmd::run(),
         }
         Ok(())
+    }
+}
+
+fn print_subcommand_help(name: &str) {
+    let mut cmd = Root::command();
+    if let Some(sub) = cmd.find_subcommand_mut(name) {
+        let _ = sub.print_long_help();
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,8 +3,7 @@ pub mod encode;
 pub mod version;
 pub mod zero;
 
-use clap::{CommandFactory, Parser, Subcommand};
-use std::io::IsTerminal;
+use clap::{Parser, Subcommand};
 use std::{ffi::OsString, fmt::Debug};
 
 #[derive(Parser, Debug, Clone)]
@@ -49,25 +48,12 @@ impl Root {
     /// If the root command is configured with state that is invalid.
     pub fn run(&self) -> Result<(), Error> {
         match &self.cmd {
-            Cmd::Decode(c) if c.strkey.is_none() && std::io::stdin().is_terminal() => {
-                print_subcommand_help("decode");
-            }
-            Cmd::Encode(c) if c.json.is_none() && std::io::stdin().is_terminal() => {
-                print_subcommand_help("encode");
-            }
             Cmd::Decode(c) => c.run()?,
             Cmd::Encode(c) => c.run()?,
             Cmd::Zero(c) => c.run(),
             Cmd::Version => version::Cmd::run(),
         }
         Ok(())
-    }
-}
-
-fn print_subcommand_help(name: &str) {
-    let mut cmd = Root::command();
-    if let Some(sub) = cmd.find_subcommand_mut(name) {
-        let _ = sub.print_long_help();
     }
 }
 

--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -43,7 +43,8 @@ impl Strkey {
     // SignedPayload is the longest strkey type.
     const MAX_PAYLOAD_LEN: usize = ed25519::SignedPayload::MAX_PAYLOAD_LEN;
     const MAX_BINARY_LEN: usize = binary_len(Self::MAX_PAYLOAD_LEN);
-    const MAX_ENCODED_LEN: usize = encode_len(Self::MAX_BINARY_LEN);
+    /// The maximum length, in bytes, of any strkey's encoded string form.
+    pub const MAX_ENCODED_LEN: usize = encode_len(Self::MAX_BINARY_LEN);
     const _ASSERTS: () = {
         assert!(Self::MAX_PAYLOAD_LEN == 100);
         assert!(Self::MAX_BINARY_LEN == 103);

--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -43,8 +43,7 @@ impl Strkey {
     // SignedPayload is the longest strkey type.
     const MAX_PAYLOAD_LEN: usize = ed25519::SignedPayload::MAX_PAYLOAD_LEN;
     const MAX_BINARY_LEN: usize = binary_len(Self::MAX_PAYLOAD_LEN);
-    /// The maximum length, in bytes, of any strkey's encoded string form.
-    pub const MAX_ENCODED_LEN: usize = encode_len(Self::MAX_BINARY_LEN);
+    pub(crate) const MAX_ENCODED_LEN: usize = encode_len(Self::MAX_BINARY_LEN);
     const _ASSERTS: () = {
         assert!(Self::MAX_PAYLOAD_LEN == 100);
         assert!(Self::MAX_BINARY_LEN == 103);


### PR DESCRIPTION
### What
Make the strkey argument to `decode` and the json argument to `encode` optional. When omitted, read input from stdin.

### Why
Enable piping into the CLI for scripting and composition with other tools, avoiding the need to pass values as shell arguments where escaping or length limits can be awkward. Also some strkeys contain secret/private keys and passing that type of data via stdin is better practice.