### PR TITLE
Use shared claude-review reusable workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,8 @@
 name: Claude Review
+
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [ready_for_review, synchronize]
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
@@ -11,42 +12,6 @@ permissions: {}
 
 jobs:
   review:
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          track_progress: true
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Please review this pull request with a focus on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security implications
-            - Performance considerations
-
-            Provide detailed feedback using inline comments for specific issues.
-
-            When using GitHub CLI commands always include the PR number explicitly,
-            e.g. `gh pr diff ${{ github.event.pull_request.number }}`,
-            `gh pr view ${{ github.event.pull_request.number }}`,
-            `gh pr comment ${{ github.event.pull_request.number }} --body "..."`.
-            Do not rely on the current directory context to infer the PR number.
-
-          # --max-turns caps how many tool-use cycles Claude can run, which
-          # bounds token spend per invocation. The allowed `gh pr` commands are
-          # scoped to this PR's number so a misfire can't reach into another PR.
-          claude_args: |
-            --max-turns 30
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment ${{ github.event.pull_request.number }}:*),Bash(gh pr diff ${{ github.event.pull_request.number }}:*),Bash(gh pr view ${{ github.event.pull_request.number }}:*)"
+    uses: stellar/actions/.github/workflows/claude-review.yml@main
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
### What
Replace the inlined `claude-review.yml` workflow with a call to the shared reusable workflow at `stellar/actions/.github/workflows/claude-review.yml@main`. Keep the existing `pull_request` trigger (the safer default; fork PRs can't access secrets on this event so they cannot be reviewed) and narrow the trigger types to `[ready_for_review, synchronize]` so Claude only reviews PRs that are marked ready and re-reviews on new commits.

### Why
The same claude-review workflow is maintained across four stellar repos. Moving to `stellar/actions` lets all repos share one implementation, so the security model and prompt updates live in one place. The reusable workflow also adopts the harder `pull_request_target` flow with an author-association gate, enabling reviews of fork PRs from org members while still keeping secrets out of attacker-controlled code paths.

### Example

Before — fully inlined workflow with `pull_request` trigger and bespoke prompt.

After:

```yaml
name: Claude Review

on:
  pull_request:
    types: [ready_for_review, synchronize]

concurrency:
  group: claude-review-${{ github.event.pull_request.number }}
  cancel-in-progress: true

permissions: {}

jobs:
  review:
    uses: stellar/actions/.github/workflows/claude-review.yml@main
    secrets:
      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
```

The default prompt in the reusable workflow matches the one used here previously, with an added note that the PR head is checked out into `pr-head/`.

### Note

Requires the corresponding PR in `stellar/actions` to be merged first so that `stellar/actions/.github/workflows/claude-review.yml@main` resolves:
- https://github.com/stellar/actions/pull/103