### PR TITLE
Add structured DecodeError variants

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -135,10 +135,10 @@ pub fn encode_zeroizing<const P: usize, const B: usize, const E: usize>(
 ///
 /// # Errors
 ///
-/// Returns [`DecodeError::Invalid`] if:
-/// - The input is not valid base32
-/// - The decoded data is less than 3 bytes, meaning there is no payload
-/// - The checksum does not match
+/// - [`DecodeError::InvalidBase32`] if the input is not valid base32.
+/// - [`DecodeError::TooShort`] if the decoded data is less than 3 bytes.
+/// - [`DecodeError::TooLong`] if the decoded data is larger than `B`.
+/// - [`DecodeError::ChecksumMismatch`] if the checksum does not match.
 ///
 /// # Panics
 ///
@@ -152,17 +152,17 @@ pub fn decode<const P: usize, const B: usize>(s: &[u8]) -> Result<(u8, Vec<u8, P
     let mut data: Vec<u8, B> = Vec::new();
     let data_len = data_encoding::BASE32_NOPAD
         .decode_len(s.len())
-        .map_err(|_| DecodeError::Invalid)?;
+        .map_err(|_| DecodeError::InvalidBase32)?;
     if data_len < 3 {
-        return Err(DecodeError::Invalid);
+        return Err(DecodeError::TooShort);
     }
     data.resize_default(data_len)
-        .map_err(|_| DecodeError::Invalid)?;
+        .map_err(|_| DecodeError::TooLong)?;
 
     // Decode base32.
     data_encoding::BASE32_NOPAD
         .decode_mut(s, &mut data)
-        .map_err(|_| DecodeError::Invalid)?;
+        .map_err(|_| DecodeError::InvalidBase32)?;
 
     // Unpack version.
     let ver = data[0];
@@ -172,7 +172,7 @@ pub fn decode<const P: usize, const B: usize>(s: &[u8]) -> Result<(u8, Vec<u8, P
     let (data_without_crc, crc_actual) = data.split_at(data_len - 2);
     let crc_expect = checksum(data_without_crc);
     if crc_actual != crc_expect {
-        return Err(DecodeError::Invalid);
+        return Err(DecodeError::ChecksumMismatch);
     }
 
     // Unpack payload.
@@ -212,17 +212,17 @@ pub fn decode_zeroizing<const P: usize, const B: usize>(
     let mut data: Zeroizing<Vec<u8, B>> = Zeroizing::new(Vec::new());
     let data_len = data_encoding::BASE32_NOPAD
         .decode_len(s.len())
-        .map_err(|_| DecodeError::Invalid)?;
+        .map_err(|_| DecodeError::InvalidBase32)?;
     if data_len < 3 {
-        return Err(DecodeError::Invalid);
+        return Err(DecodeError::TooShort);
     }
     data.resize_default(data_len)
-        .map_err(|_| DecodeError::Invalid)?;
+        .map_err(|_| DecodeError::TooLong)?;
 
     // Decode base32.
     data_encoding::BASE32_NOPAD
         .decode_mut(s, &mut data)
-        .map_err(|_| DecodeError::Invalid)?;
+        .map_err(|_| DecodeError::InvalidBase32)?;
 
     // Unpack version.
     let ver = data[0];
@@ -232,7 +232,7 @@ pub fn decode_zeroizing<const P: usize, const B: usize>(
     let (data_without_crc, crc_actual) = data.split_at(data_len - 2);
     let crc_expect = checksum(data_without_crc);
     if crc_actual != crc_expect {
-        return Err(DecodeError::Invalid);
+        return Err(DecodeError::ChecksumMismatch);
     }
 
     // Copy the payload bytes directly into the caller-provided output. No
@@ -288,10 +288,10 @@ mod tests {
     #[test]
     fn test_decode_minimum_length() {
         // Empty input should fail
-        assert_eq!(decode::<0, 3>(b""), Err(DecodeError::Invalid));
+        assert_eq!(decode::<0, 3>(b""), Err(DecodeError::TooShort));
         // Too short base32 (decodes to < 3 bytes) should fail
-        assert_eq!(decode::<0, 3>(b"AA"), Err(DecodeError::Invalid)); // 1 byte
-        assert_eq!(decode::<0, 3>(b"AAAA"), Err(DecodeError::Invalid)); // 2 bytes
+        assert_eq!(decode::<0, 3>(b"AA"), Err(DecodeError::TooShort)); // 1 byte
+        assert_eq!(decode::<0, 3>(b"AAAA"), Err(DecodeError::TooShort)); // 2 bytes
 
         // Valid 3-byte input (version + empty payload + checksum) should succeed
         // "AAAAA" is encode::<0, 3, 5>(0x00, &[]) - version 0x00, empty payload, checksum 0x0000
@@ -381,7 +381,7 @@ mod tests {
 
         // Same buffer, invalid input — must reset, not retain prior payload.
         let err = decode_zeroizing::<32, 35>(b"", &mut buf);
-        assert_eq!(err, Err(DecodeError::Invalid));
+        assert_eq!(err, Err(DecodeError::TooShort));
         assert!(buf.is_empty());
     }
 }

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -88,7 +88,7 @@ impl PrivateKey {
     pub fn from_payload(payload: &[u8]) -> Result<Self, DecodeError> {
         match payload.try_into() {
             Ok(ed25519) => Ok(Self(ed25519)),
-            Err(_) => Err(DecodeError::Invalid),
+            Err(_) => Err(DecodeError::InvalidPayloadLength),
         }
     }
 
@@ -101,7 +101,7 @@ impl PrivateKey {
         let ver = decode_zeroizing::<{ Self::PAYLOAD_LEN }, { Self::BINARY_LEN }>(s, &mut payload)?;
         match ver {
             version::PRIVATE_KEY_ED25519 => Self::from_payload(&payload),
-            _ => Err(DecodeError::Invalid),
+            _ => Err(DecodeError::UnsupportedVersion),
         }
     }
 
@@ -220,7 +220,7 @@ impl PublicKey {
     pub fn from_payload(payload: &[u8]) -> Result<Self, DecodeError> {
         match payload.try_into() {
             Ok(ed25519) => Ok(Self(ed25519)),
-            Err(_) => Err(DecodeError::Invalid),
+            Err(_) => Err(DecodeError::InvalidPayloadLength),
         }
     }
 
@@ -232,7 +232,7 @@ impl PublicKey {
         let (ver, payload) = decode::<{ Self::PAYLOAD_LEN }, { Self::BINARY_LEN }>(s)?;
         match ver {
             version::PUBLIC_KEY_ED25519 => Self::from_payload(&payload),
-            _ => Err(DecodeError::Invalid),
+            _ => Err(DecodeError::UnsupportedVersion),
         }
     }
 }
@@ -326,13 +326,18 @@ impl MuxedAccount {
     }
 
     pub fn from_payload(payload: &[u8]) -> Result<Self, DecodeError> {
-        if payload.len() < 40 {
-            return Err(DecodeError::Invalid);
+        if payload.len() != 40 {
+            return Err(DecodeError::InvalidPayloadLength);
         }
         let (ed25519, id) = payload.split_at(32);
         Ok(Self {
-            ed25519: ed25519.try_into().map_err(|_| DecodeError::Invalid)?,
-            id: u64::from_be_bytes(id.try_into().map_err(|_| DecodeError::Invalid)?),
+            ed25519: ed25519
+                .try_into()
+                .map_err(|_| DecodeError::InvalidPayloadLength)?,
+            id: u64::from_be_bytes(
+                id.try_into()
+                    .map_err(|_| DecodeError::InvalidPayloadLength)?,
+            ),
         })
     }
 
@@ -344,7 +349,7 @@ impl MuxedAccount {
         let (ver, payload) = decode::<{ Self::PAYLOAD_LEN }, { Self::BINARY_LEN }>(s)?;
         match ver {
             version::MUXED_ACCOUNT_ED25519 => Self::from_payload(&payload),
-            _ => Err(DecodeError::Invalid),
+            _ => Err(DecodeError::UnsupportedVersion),
         }
     }
 }
@@ -452,11 +457,11 @@ impl SignedPayload {
     /// If the inner payload is empty or larger than 64 bytes.
     pub fn new(ed25519: [u8; 32], payload: &[u8]) -> Result<Self, DecodeError> {
         if !(Self::MIN_INNER_PAYLOAD_LEN..=Self::MAX_INNER_PAYLOAD_LEN).contains(&payload.len()) {
-            return Err(DecodeError::Invalid);
+            return Err(DecodeError::InvalidPayloadLength);
         }
         let mut p = Vec::new();
         p.extend_from_slice(payload)
-            .map_err(|_| DecodeError::Invalid)?;
+            .map_err(|_| DecodeError::InvalidPayloadLength)?;
         Ok(Self {
             ed25519,
             payload: p,
@@ -508,37 +513,37 @@ impl SignedPayload {
         const MAX_LENGTH: usize = 32 + 4 + SignedPayload::MAX_INNER_PAYLOAD_LEN;
         let payload_len = payload.len();
         if !(MIN_LENGTH..=MAX_LENGTH).contains(&payload_len) {
-            return Err(DecodeError::Invalid);
+            return Err(DecodeError::InvalidPayloadLength);
         }
 
         // Decode ed25519 public key. 32 bytes.
         let mut offset = 0;
         let ed25519: [u8; 32] = payload
             .get(offset..offset + 32)
-            .ok_or(DecodeError::Invalid)?
+            .ok_or(DecodeError::InvalidPayloadLength)?
             .try_into()
-            .map_err(|_| DecodeError::Invalid)?;
+            .map_err(|_| DecodeError::InvalidPayloadLength)?;
         offset += 32;
 
         // Decode inner payload length. 4 bytes.
         let inner_payload_len = u32::from_be_bytes(
             payload
                 .get(offset..offset + 4)
-                .ok_or(DecodeError::Invalid)?
+                .ok_or(DecodeError::InvalidPayloadLength)?
                 .try_into()
-                .map_err(|_| DecodeError::Invalid)?,
+                .map_err(|_| DecodeError::InvalidPayloadLength)?,
         );
         offset += 4;
 
         // Check inner payload length is inside accepted range.
         if inner_payload_len > Self::MAX_INNER_PAYLOAD_LEN_U32 {
-            return Err(DecodeError::Invalid);
+            return Err(DecodeError::InvalidPayloadLength);
         }
 
         // Decode inner payload.
         let inner_payload = payload
             .get(offset..offset + inner_payload_len as usize)
-            .ok_or(DecodeError::Invalid)?;
+            .ok_or(DecodeError::InvalidPayloadLength)?;
         offset += inner_payload_len as usize;
 
         // Calculate padding at end of inner payload. 0-3 bytes.
@@ -547,17 +552,17 @@ impl SignedPayload {
         // Decode padding.
         let padding = payload
             .get(offset..offset + padding_len as usize)
-            .ok_or(DecodeError::Invalid)?;
+            .ok_or(DecodeError::InvalidPayloadLength)?;
         offset += padding_len as usize;
 
         // Check padding is all zeros.
         if padding.iter().any(|b| *b != 0) {
-            return Err(DecodeError::Invalid);
+            return Err(DecodeError::InvalidPadding);
         }
 
         // Check that entire payload consumed.
         if offset != payload_len {
-            return Err(DecodeError::Invalid);
+            return Err(DecodeError::InvalidPayloadLength);
         }
 
         Self::new(ed25519, inner_payload)
@@ -571,7 +576,7 @@ impl SignedPayload {
         let (ver, payload) = decode::<{ Self::MAX_PAYLOAD_LEN }, { Self::MAX_BINARY_LEN }>(s)?;
         match ver {
             version::SIGNED_PAYLOAD_ED25519 => Self::from_payload(&payload),
-            _ => Err(DecodeError::Invalid),
+            _ => Err(DecodeError::UnsupportedVersion),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,29 @@
+/// An error returned when decoding a strkey.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum DecodeError {
-    // TODO: Add meaningful errors for each problem that can occur.
-    Invalid,
+    /// The input is not valid base32 (no padding): an invalid symbol, an
+    /// invalid encoded length, or non-zero trailing bits were encountered.
+    InvalidBase32,
+    /// The decoded data is shorter than the minimum required to contain a
+    /// version byte and CRC.
+    TooShort,
+    /// The decoded data is longer than the maximum the requested strkey kind
+    /// can hold.
+    TooLong,
+    /// The CRC16-XMODEM checksum did not match.
+    ChecksumMismatch,
+    /// The version byte is not a supported strkey kind for the type being
+    /// decoded.
+    UnsupportedVersion,
+    /// The claimable-balance sub-version byte (the first byte of the payload)
+    /// is not a supported claimable-balance version. Only `V0` (`0x00`) is
+    /// defined.
+    UnsupportedClaimableBalanceVersion,
+    /// The decoded payload does not have the expected length for the strkey
+    /// kind.
+    InvalidPayloadLength,
+    /// The payload contains padding bytes that must be zero but are not.
+    InvalidPadding,
     /// The input is `S`-prefixed and may be a private-key strkey. `Strkey`
     /// does not parse `S…`. Route the input to
     /// [`ed25519::PrivateKey`](crate::ed25519::PrivateKey).
@@ -11,8 +33,23 @@ pub enum DecodeError {
 impl core::fmt::Display for DecodeError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
-            DecodeError::Invalid {} => f.write_str("the strkey is invalid"),
-            DecodeError::PrivateKey {} => {
+            DecodeError::InvalidBase32 => f.write_str("the strkey is not valid base32"),
+            DecodeError::TooShort => f.write_str("the strkey decodes to fewer bytes than required"),
+            DecodeError::TooLong => f.write_str("the strkey decodes to more bytes than allowed"),
+            DecodeError::ChecksumMismatch => f.write_str("the strkey checksum does not match"),
+            DecodeError::UnsupportedVersion => {
+                f.write_str("the strkey version byte is not a supported kind")
+            }
+            DecodeError::UnsupportedClaimableBalanceVersion => f.write_str(
+                "the strkey claimable-balance sub-version byte is not a supported version",
+            ),
+            DecodeError::InvalidPayloadLength => {
+                f.write_str("the strkey payload is not the expected length")
+            }
+            DecodeError::InvalidPadding => {
+                f.write_str("the strkey payload has non-zero padding bytes")
+            }
+            DecodeError::PrivateKey => {
                 f.write_str("the strkey is `S`-prefixed; use ed25519::PrivateKey to decode it")
             }
         }

--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -119,7 +119,7 @@ impl Strkey {
             version::CLAIMABLE_BALANCE => Ok(Self::ClaimableBalance(
                 ClaimableBalance::from_payload(&payload)?,
             )),
-            _ => Err(DecodeError::Invalid),
+            _ => Err(DecodeError::UnsupportedVersion),
         }
     }
 }
@@ -295,7 +295,11 @@ impl PreAuthTx {
     }
 
     fn from_payload(payload: &[u8]) -> Result<Self, DecodeError> {
-        Ok(Self(payload.try_into().map_err(|_| DecodeError::Invalid)?))
+        Ok(Self(
+            payload
+                .try_into()
+                .map_err(|_| DecodeError::InvalidPayloadLength)?,
+        ))
     }
 
     pub fn from_string(s: &str) -> Result<Self, DecodeError> {
@@ -306,7 +310,7 @@ impl PreAuthTx {
         let (ver, payload) = decode::<{ Self::PAYLOAD_LEN }, { Self::BINARY_LEN }>(s)?;
         match ver {
             version::PRE_AUTH_TX => Self::from_payload(&payload),
-            _ => Err(DecodeError::Invalid),
+            _ => Err(DecodeError::UnsupportedVersion),
         }
     }
 }
@@ -392,7 +396,11 @@ impl HashX {
     }
 
     fn from_payload(payload: &[u8]) -> Result<Self, DecodeError> {
-        Ok(Self(payload.try_into().map_err(|_| DecodeError::Invalid)?))
+        Ok(Self(
+            payload
+                .try_into()
+                .map_err(|_| DecodeError::InvalidPayloadLength)?,
+        ))
     }
 
     pub fn from_string(s: &str) -> Result<Self, DecodeError> {
@@ -403,7 +411,7 @@ impl HashX {
         let (ver, payload) = decode::<{ Self::PAYLOAD_LEN }, { Self::BINARY_LEN }>(s)?;
         match ver {
             version::HASH_X => Self::from_payload(&payload),
-            _ => Err(DecodeError::Invalid),
+            _ => Err(DecodeError::UnsupportedVersion),
         }
     }
 }
@@ -489,7 +497,11 @@ impl Contract {
     }
 
     fn from_payload(payload: &[u8]) -> Result<Self, DecodeError> {
-        Ok(Self(payload.try_into().map_err(|_| DecodeError::Invalid)?))
+        Ok(Self(
+            payload
+                .try_into()
+                .map_err(|_| DecodeError::InvalidPayloadLength)?,
+        ))
     }
 
     pub fn from_string(s: &str) -> Result<Self, DecodeError> {
@@ -500,7 +512,7 @@ impl Contract {
         let (ver, payload) = decode::<{ Self::PAYLOAD_LEN }, { Self::BINARY_LEN }>(s)?;
         match ver {
             version::CONTRACT => Self::from_payload(&payload),
-            _ => Err(DecodeError::Invalid),
+            _ => Err(DecodeError::UnsupportedVersion),
         }
     }
 }
@@ -586,7 +598,11 @@ impl LiquidityPool {
     }
 
     fn from_payload(payload: &[u8]) -> Result<Self, DecodeError> {
-        Ok(Self(payload.try_into().map_err(|_| DecodeError::Invalid)?))
+        Ok(Self(
+            payload
+                .try_into()
+                .map_err(|_| DecodeError::InvalidPayloadLength)?,
+        ))
     }
 
     pub fn from_string(s: &str) -> Result<Self, DecodeError> {
@@ -597,7 +613,7 @@ impl LiquidityPool {
         let (ver, payload) = decode::<{ Self::PAYLOAD_LEN }, { Self::BINARY_LEN }>(s)?;
         match ver {
             version::LIQUIDITY_POOL => Self::from_payload(&payload),
-            _ => Err(DecodeError::Invalid),
+            _ => Err(DecodeError::UnsupportedVersion),
         }
     }
 }
@@ -702,8 +718,12 @@ impl ClaimableBalance {
     fn from_payload(payload: &[u8]) -> Result<Self, DecodeError> {
         match payload {
             // First byte is zero for v0
-            [0, rest @ ..] => Ok(Self::V0(rest.try_into().map_err(|_| DecodeError::Invalid)?)),
-            _ => Err(DecodeError::Invalid),
+            [0, rest @ ..] => Ok(Self::V0(
+                rest.try_into()
+                    .map_err(|_| DecodeError::InvalidPayloadLength)?,
+            )),
+            [_, ..] => Err(DecodeError::UnsupportedClaimableBalanceVersion),
+            [] => Err(DecodeError::InvalidPayloadLength),
         }
     }
 
@@ -715,7 +735,7 @@ impl ClaimableBalance {
         let (ver, payload) = decode::<{ Self::PAYLOAD_LEN }, { Self::BINARY_LEN }>(s)?;
         match ver {
             version::CLAIMABLE_BALANCE => Self::from_payload(&payload),
-            _ => Err(DecodeError::Invalid),
+            _ => Err(DecodeError::UnsupportedVersion),
         }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -30,27 +30,39 @@ fn test_invalid_public_keys() {
     // Too long strkey input.
     let mut r: Result<Strkey, _> =
         "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJV75ERQ".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // Invalid length (Ed25519 should be 32 bytes, not 5).
     r = "GAAAAAAAACGC6".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // Invalid length (congruent to 1 mod 8).
     r = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZA".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
 
     // Invalid length (base-32 decoding should yield 35 bytes, not 36).
     r = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUACUSI".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // Invalid algorithm (low 3 bits of version byte are 7).
     r = "G47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVP2I".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::UnsupportedVersion));
 
     // Invalid length due to in stream padding bytes
     r = "G=3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQHES5".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
+}
+
+#[test]
+fn test_strkey_too_short() {
+    // Empty input decodes to zero bytes, less than the 3 bytes required for a
+    // version byte plus CRC.
+    let r: Result<Strkey, _> = "".parse();
+    assert_eq!(r, Err(DecodeError::TooShort));
+
+    // Decodes to 2 bytes, still below the 3-byte minimum.
+    let r: Result<Strkey, _> = "AAAA".parse();
+    assert_eq!(r, Err(DecodeError::TooShort));
 }
 
 #[test]
@@ -103,7 +115,7 @@ fn test_valid_pre_auth_tx() {
 fn test_invalid_pre_auth_tx() {
     // Too long strkey input.
     let r: Result<Strkey, _> = "TA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJV73QGA".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 }
 
 #[test]
@@ -122,7 +134,7 @@ fn test_valid_hash_x() {
 fn test_invalid_hash_x() {
     // Too long strkey input.
     let r: Result<Strkey, _> = "XA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJV74CSY".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 }
 
 #[test]
@@ -172,38 +184,45 @@ fn test_invalid_muxed_ed25519() {
     // Too long strkey input.
     let mut r: Result<Strkey, _> =
         "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUERUKZ4JVTO6777RIDA".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // The unused trailing bit must be zero in the encoding of the last three
     // bytes (24 bits) as five base-32 symbols (25 bits)
     // 1000_ Q << The last character should be Q, because the last bit is unused, and in
     // 10001 R << the base32 alphabet 10000 maps to Q. 10001 maps to R.
     r = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUR".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
 
     // Invalid length (congruent to 6 mod 8)
     r = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLKA".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
 
     // Invalid length (base-32 decoding should yield 43 bytes, not 44)
     r = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAAV75I".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
-    // Invalid algorithm (low 3 bits of version byte are 7)
+    // TODO: This case is meant to exercise the "invalid algorithm (low 3 bits
+    // of version byte are 7)" rejection path, but the CRC bytes still match
+    // the original `M` version, so flipping to `M4` trips the checksum check
+    // before the version-byte match. The following input has version byte
+    // `(12 << 3) | 7 = 0x67` ("M4" prefix) with a CRC recomputed for that
+    // version byte, and a zeroed 40-byte payload, which would actually surface
+    // as `UnsupportedVersion`:
+    //   "M4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC4ZS"
     r = "M47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::ChecksumMismatch));
 
     // Padding bytes are not allowed
     r = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUK===".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
 
     // Invalid checksum
     r = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUO".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::ChecksumMismatch));
 
     // Too short
     r = "MA7QYNF7SOWQ3GLR2DMLK".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 }
 
 #[test]
@@ -290,117 +309,117 @@ fn test_valid_signed_payload_ed25519() {
 
 #[test]
 fn test_invalid_signed_payload_ed25519() {
-    // Too long strkey input.
+    // Too long strkey input — decodes to more bytes than the buffer for any kind.
     let mut r: Result<Strkey, DecodeError>;
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAABAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD7ZIHA".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::TooLong));
 
     // Length prefix specifies length that is shorter than payload in signed payload
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IAAAAAAAAPM".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // Length prefix specifies length that is longer than payload in signed payload
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4Z2PQ".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // No zero padding in signed payload
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DXFH6".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // Non-zero padding in signed payload
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAA4KVWLTJJFCJJFC7MPA7QYNF7SOWQ3GLR2GXUA7JUAAAAAEAAAAU".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPadding));
 
     // Unused trailing bits must be zero (see valid test case for comparisons)
     // - 1 unused bits:
     //   1001_ S << The last character should be S, because the last bit is unused, and in
     //   10011 T << the base32 alphabet 10010 maps to S. 10011 maps to T.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAACAAAAAABNWT".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     // - 2 unused bits:
     //   110__ Y << The last character should be Y, because the last two bits are unused, and in
     //   11001 Z << the base32 alphabet 11000 maps to Y. 11001 maps to Z.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAGAAAAAAAAAAAAAAAAAAACTPZ"
         .parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   11010 2 << 11010 maps to 2.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAGAAAAAAAAAAAAAAAAAAACTP2"
         .parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   11011 3 << 11011 maps to 3.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAGAAAAAAAAAAAAAAAAAAACTP3"
         .parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     // - 3 unused bits:
     //   01___ I << The last character should be I, because the last three bits are unused, and in
     //   01001 J << the base32 alphabet 01000 maps to I. 01001 maps to J.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALGXJ".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   01010 J << 01010 maps to K.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALGXK".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   01011 L << 01011 maps to L.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALGXL".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   01100 M << 01100 maps to M.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALGXM".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   01101 N << 01101 maps to N.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALGXN".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   01110 O << 01110 maps to O.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALGXO".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   01111 P << 01111 maps to P.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALGXP".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     // - 4 unused bits:
     //   1____ Q << The last character should be Q, because the last four bits are unused, and in
     //   10001 R << the base32 alphabet 10000 maps to Q. 10001 maps to R.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKYR".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   10010 S << 10010 maps to S.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKYS".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   10011 T << 10011 maps to T.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKYT".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   10100 U << 10100 maps to U.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKYU".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   10101 V << 10101 maps to V.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKYV".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   10110 W << 10110 maps to W.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKYW".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   10111 X << 10111 maps to X.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKYX".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   11000 Y << 11000 maps to Y.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKYY".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   11001 Z << 11001 maps to Z.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKYZ".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   11010 2 << 11010 maps to 2.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKY2".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   11011 3 << 11011 maps to 3.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKY3".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   11100 4 << 11100 maps to 4.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKY4".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   11101 5 << 11101 maps to 5.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKY5".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   11110 6 << 11110 maps to 6.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKY6".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   11111 7 << 11111 maps to 7.
     r = "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAEAAAAAAAAAAAAARKY7".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
 }
 
 #[test]
@@ -464,7 +483,7 @@ fn test_valid_contract() {
 fn test_invalid_contract() {
     // Too long strkey input.
     let r: Result<Strkey, _> = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJV72WFI".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 }
 
 #[test]
@@ -473,11 +492,11 @@ fn test_signed_payload_new_rejects_empty_and_oversized_payload() {
     // an encoding that from_payload() will refuse to decode (a 36-byte
     // signed-payload layout is not accepted by stellar-core either).
     let r = stellar_strkey::ed25519::SignedPayload::new([0; 32], &[]);
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // Payloads larger than 64 bytes must be rejected.
     let r = stellar_strkey::ed25519::SignedPayload::new([0; 32], &[0u8; 65]);
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // 1..=64 are accepted.
     assert!(stellar_strkey::ed25519::SignedPayload::new([0; 32], &[0]).is_ok());
@@ -492,7 +511,7 @@ fn test_signed_payload_from_string_doesnt_panic_with_unbounded_size() {
         0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     ];
     let r = stellar_strkey::ed25519::SignedPayload::from_payload(payload);
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 }
 
 /// Tests for SignedPayload::from_payload boundary conditions.
@@ -527,7 +546,7 @@ fn test_signed_payload_from_payload_min_length_boundary() {
     let result = stellar_strkey::ed25519::SignedPayload::from_payload(payload);
     assert_eq!(
         result,
-        Err(DecodeError::Invalid),
+        Err(DecodeError::InvalidPayloadLength),
         "39 bytes (below MIN_LENGTH) should fail"
     );
 }
@@ -551,7 +570,7 @@ fn test_signed_payload_from_payload_max_length_boundary() {
     let result = stellar_strkey::ed25519::SignedPayload::from_payload(payload);
     assert_eq!(
         result,
-        Err(DecodeError::Invalid),
+        Err(DecodeError::InvalidPayloadLength),
         "101 bytes (above MAX_LENGTH) should fail"
     );
 }
@@ -576,7 +595,7 @@ fn test_signed_payload_from_payload_inner_length_boundary() {
     let result = stellar_strkey::ed25519::SignedPayload::from_payload(payload);
     assert_eq!(
         result,
-        Err(DecodeError::Invalid),
+        Err(DecodeError::InvalidPayloadLength),
         "inner payload length 65 should fail"
     );
 
@@ -623,33 +642,33 @@ fn test_invalid_liquidity_pool() {
     // Too long strkey input.
     let mut r: Result<Strkey, _> =
         "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJV7Z72Y".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // Invalid length (Liquidity pool should be 32 bytes, not 5).
     r = "LAAAAAAAADLH2".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // Invalid length (congruent to 1 mod 8).
     r = "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJNA".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     // Invalid length (congruent to 3 mod 8).
     r = "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJNAAA".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     // Invalid length (congruent to 6 mod 8).
     r = "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJNAAAAAA".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
 
     // Invalid length (base-32 decoding should yield 35 bytes, not 36).
     r = "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAGPZA".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // Invalid algorithm (low 3 bits of version byte are 7).
     r = "L47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUSV4".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::UnsupportedVersion));
 
     // Invalid length due to in stream padding bytes
     r = "L=A7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJN".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
 }
 
 #[test]
@@ -697,14 +716,21 @@ fn test_valid_claimable_balance() {
 
 #[test]
 fn test_invalid_claimable_balances() {
-    // Too long strkey input.
+    // TODO: This test input is prefixed with `L`, not `B`, so it actually
+    // routes through `LiquidityPool` decoding and fails with
+    // `InvalidPayloadLength`. It is not exercising the claimable-balance
+    // "too long" path the comment implies. A `B`-prefixed input that is
+    // genuinely too long for a claimable balance (34-byte payload, binary
+    // length 37, with a valid CRC) would also produce `InvalidPayloadLength`
+    // via the claimable-balance path:
+    //   "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZMEQ"
     let mut r: Result<Strkey, _> =
         "LAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGX7FIWQ".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // Invalid length (Claimable balance should be 1+32 bytes, not 6).
     r = "BAAAAAAAAAAK3EY".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // Invalid length inputs below cannot be decoded into valid claimable
     // balances, even with a permissive base32 decoder, because the payloads
@@ -715,25 +741,32 @@ fn test_invalid_claimable_balances() {
     // the payloads can be valid.
     // Invalid length (congruent to 3 mod 8).
     r = "BAADMPVKHBTYIH522D2O3CGHPHSP4ZXFNISHBXEYYDWJYBZ5AXD3CA3GDEA".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     // Invalid length (congruent to 6 mod 8).
     r = "BAADMPVKHBTYIH522D2O3CGHPHSP4ZXFNISHBXEYYDWJYBZ5AXD3CA3GDEAAAA".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     // Invalid length (congruent to 1 mod 8).
     r = "BAADMPVKHBTYIH522D2O3CGHPHSP4ZXFNISHBXEYYDWJYBZ5AXD3CA3GDEAAAAAAA".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
 
-    // Invalid length (base-32 decoding should yield 35 bytes, not 36).
+    // TODO: The comment says "base-32 decoding should yield 35 bytes, not 36"
+    // but a claimable balance's binary length is 36 bytes (1 version + 1 sub +
+    // 32 hash + 2 CRC). This input decodes fine, but its sub-version byte
+    // isn't zero, so it fails with `UnsupportedClaimableBalanceVersion`
+    // rather than a length error. A `B`-prefixed input whose binary decodes
+    // to 35 bytes (one short of the expected 36) with a valid CRC would
+    // exercise the length path and produce `InvalidPayloadLength`:
+    //   "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBO"
     r = "BA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUADTYY".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::UnsupportedClaimableBalanceVersion));
 
     // Invalid algorithm (low 3 bits of version byte are 7).
     r = "B47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVA4D".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::UnsupportedVersion));
 
     // Invalid length due to in stream padding bytes
     r = "B=AAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
 
     // Unused trailing bits must be zero (see valid test case for comparisons)
     // - 2 unused bits:
@@ -742,18 +775,18 @@ fn test_invalid_claimable_balances() {
     //              10100 maps to U.
     //   10101 V << 10101 maps to V.
     r = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TV".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   10110 W << 10110 maps to W.
     r = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TW".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
     //   10111 X << 10111 maps to X.
     r = "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TX".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::InvalidBase32));
 
     // Invalid type of claimable balance, only V0 (0x00) is supported. This key
     // contains 0x01.
     r = "BAAT6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGXACA".parse();
-    assert_eq!(r, Err(DecodeError::Invalid));
+    assert_eq!(r, Err(DecodeError::UnsupportedClaimableBalanceVersion));
 }
 
 proptest! {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -201,16 +201,20 @@ fn test_invalid_muxed_ed25519() {
     r = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAAV75I".parse();
     assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
-    // TODO: This case is meant to exercise the "invalid algorithm (low 3 bits
-    // of version byte are 7)" rejection path, but the CRC bytes still match
-    // the original `M` version, so flipping to `M4` trips the checksum check
-    // before the version-byte match. The following input has version byte
-    // `(12 << 3) | 7 = 0x67` ("M4" prefix) with a CRC recomputed for that
-    // version byte, and a zeroed 40-byte payload, which would actually surface
-    // as `UnsupportedVersion`:
-    //   "M4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC4ZS"
+    // Invalid algorithm (low 3 bits of version byte are 7). This input was
+    // produced by flipping the algorithm bits of an otherwise valid `M`
+    // strkey without recomputing the CRC, so the checksum check fires before
+    // the version-byte match — see the `M4…C4ZS` case below for an input
+    // that reaches the `UnsupportedVersion` path.
     r = "M47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ".parse();
     assert_eq!(r, Err(DecodeError::ChecksumMismatch));
+
+    // Invalid algorithm (low 3 bits of version byte are 7). Same ed25519 +
+    // id payload as the valid `MA7QYNF7…CJUQ` strkey above, but the version
+    // byte is `(12 << 3) | 7 = 0x67` with a CRC recomputed for that version
+    // byte, so the checksum check passes and the version-byte match fails.
+    r = "M47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAABIFE".parse();
+    assert_eq!(r, Err(DecodeError::UnsupportedVersion));
 
     // Padding bytes are not allowed
     r = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUK===".parse();
@@ -716,16 +720,12 @@ fn test_valid_claimable_balance() {
 
 #[test]
 fn test_invalid_claimable_balances() {
-    // TODO: This test input is prefixed with `L`, not `B`, so it actually
-    // routes through `LiquidityPool` decoding and fails with
-    // `InvalidPayloadLength`. It is not exercising the claimable-balance
-    // "too long" path the comment implies. A `B`-prefixed input that is
-    // genuinely too long for a claimable balance (34-byte payload, binary
-    // length 37, with a valid CRC) would also produce `InvalidPayloadLength`
-    // via the claimable-balance path:
-    //   "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZMEQ"
+    // Too long strkey input. `B`-prefixed with a 34-byte payload (one byte
+    // longer than a claimable balance's 33-byte payload) and a valid CRC, so
+    // decoding reaches `ClaimableBalance::from_payload` with a 34-byte
+    // payload that fails its 33-byte length check.
     let mut r: Result<Strkey, _> =
-        "LAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGX7FIWQ".parse();
+        "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGX74RYA".parse();
     assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // Invalid length (Claimable balance should be 1+32 bytes, not 6).
@@ -749,16 +749,19 @@ fn test_invalid_claimable_balances() {
     r = "BAADMPVKHBTYIH522D2O3CGHPHSP4ZXFNISHBXEYYDWJYBZ5AXD3CA3GDEAAAAAAA".parse();
     assert_eq!(r, Err(DecodeError::InvalidBase32));
 
-    // TODO: The comment says "base-32 decoding should yield 35 bytes, not 36"
-    // but a claimable balance's binary length is 36 bytes (1 version + 1 sub +
-    // 32 hash + 2 CRC). This input decodes fine, but its sub-version byte
-    // isn't zero, so it fails with `UnsupportedClaimableBalanceVersion`
-    // rather than a length error. A `B`-prefixed input whose binary decodes
-    // to 35 bytes (one short of the expected 36) with a valid CRC would
-    // exercise the length path and produce `InvalidPayloadLength`:
-    //   "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZBO"
+    // Unsupported claimable-balance sub-version. The input is the right
+    // length (decodes to 36 bytes: 1 version + 1 sub + 32 hash + 2 CRC) but
+    // its sub-version byte is non-zero, so it fails the V0 check.
     r = "BA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUADTYY".parse();
     assert_eq!(r, Err(DecodeError::UnsupportedClaimableBalanceVersion));
+
+    // Invalid length (base-32 decoding yields 35 bytes, not the expected 36).
+    // Same V0 sub-version + 32-byte hash as the valid CB strkey, but with the
+    // trailing hash byte dropped — giving a 32-byte payload (V0 + 31 of 32
+    // hash bytes) that decoding routes to `ClaimableBalance::from_payload`
+    // and fails its length check.
+    r = "BAADMPVKHBTYIH522D2O3CGHPHSP4ZXFNISHBXEYYDWJYBZ5AXD3C3NP".parse();
+    assert_eq!(r, Err(DecodeError::InvalidPayloadLength));
 
     // Invalid algorithm (low 3 bits of version byte are 7).
     r = "B47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVA4D".parse();


### PR DESCRIPTION
### What

Replace the catch-all `DecodeError::Invalid` variant with eight specific variants, each surfacing the precise failure mode encountered while decoding a strkey:

- `InvalidBase32` — invalid base32 symbol, encoded length, or non-zero trailing bits.
- `TooShort` — decoded data is below the 3-byte minimum (version + CRC).
- `TooLong` — decoded data overflows the destination buffer for the requested kind.
- `ChecksumMismatch` — CRC16-XMODEM mismatch.
- `UnsupportedVersion` — strkey version byte is not a supported kind.
- `UnsupportedClaimableBalanceVersion` — claimable-balance sub-version byte is not `V0` (`0x00`).
- `InvalidPayloadLength` — decoded payload is the wrong length for the requested kind.
- `InvalidPadding` — non-zero padding bytes in a signed-payload encoding.

`PrivateKey` is unchanged.

Every site in `src/convert.rs`, `src/strkey.rs`, and `src/ed25519.rs` that previously returned `DecodeError::Invalid` now returns the appropriate specific variant, and every variant has at least one test that exercises it.

### Why

The previous `DecodeError::Invalid` collapsed every decoding failure into a single value, which forced callers (CLIs, wallets, debugging tools) to either ignore the reason or duplicate the library's parsing to recover it. Distinct variants let downstream code render actionable messages, branch on the failure cleanly, and surface specific issues like CRC mismatch vs. unsupported version vs. wrong payload length.

The CLI in this crate is one such caller — its \`Decode\` error already wraps a \`DecodeError\`, and now its \`Display\` carries the precise reason without any additional plumbing.

### Example

\`\`\`rust
use stellar_strkey::{Strkey, DecodeError};

// Previously: every failure → DecodeError::Invalid.
// Now each failure mode is distinct:

assert_eq!(
    \"\".parse::<Strkey>(),
    Err(DecodeError::TooShort),
);
assert_eq!(
    \"GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJV75ERQ\".parse::<Strkey>(),
    Err(DecodeError::InvalidPayloadLength),
);
assert_eq!(
    \"G47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVP2I\".parse::<Strkey>(),
    Err(DecodeError::UnsupportedVersion),
);
assert_eq!(
    \"BAAT6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGXACA\".parse::<Strkey>(),
    Err(DecodeError::UnsupportedClaimableBalanceVersion),
);
\`\`\`