### PR TITLE
Accept owned variant keys for Decoded<Strkey>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ crate-git-revision = "0.0.9"
 [dev-dependencies]
 proptest ="1.0.0"
 serde_test = "1.0.177"
+serde_json = "1"
 
 [dependencies]
 data-encoding = { version = "2.6.0", default-features = false }

--- a/src/strkey.rs
+++ b/src/strkey.rs
@@ -193,11 +193,16 @@ mod strkey_decoded_serde_impl {
                 }
 
                 fn visit_map<M: MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
-                    let key: &str = map
+                    // Read the variant key as an owned `String`, not a borrowed
+                    // `&str`. Deserializers that don't borrow from a contiguous
+                    // input buffer — e.g. `serde_json::from_value` /
+                    // `from_reader`, and most non-JSON formats — yield owned
+                    // keys that cannot be borrowed as `&str` and would fail here.
+                    let key: alloc::string::String = map
                         .next_key()?
                         .ok_or_else(|| de::Error::custom("expected a variant key"))?;
 
-                    let strkey = match key {
+                    let strkey = match key.as_str() {
                         "public_key_ed25519" => {
                             let Decoded(inner) = map.next_value()?;
                             Strkey::PublicKeyEd25519(inner)
@@ -232,7 +237,7 @@ mod strkey_decoded_serde_impl {
                         }
                         _ => {
                             return Err(de::Error::unknown_variant(
-                                key,
+                                &key,
                                 &[
                                     "public_key_ed25519",
                                     "pre_auth_tx",

--- a/tests/cli_json.rs
+++ b/tests/cli_json.rs
@@ -123,6 +123,51 @@ fn test_ed25519_signed_payload() {
     );
 }
 
+// Regression tests for deserializing `Decoded<Strkey>` from deserializers that
+// yield owned (rather than borrowed) string keys. `serde_json::from_str`
+// borrows the variant key directly from the input buffer, but `from_value` and
+// `from_reader` cannot, so the map visitor must accept an owned key. The
+// `encode` CLI hits this via `from_value`. See issue #124.
+
+#[test]
+fn test_decode_strkey_from_value() {
+    let value = serde_json::json!({
+        "public_key_ed25519": "3330317ec241d79943bb9aa7c8ea5f8b89f9c6ea351fe03f8ec3d1127137d484",
+    });
+    let Decoded(strkey): Decoded<Strkey> = serde_json::from_value(value).unwrap();
+    assert!(matches!(strkey, Strkey::PublicKeyEd25519(_)));
+}
+
+#[test]
+fn test_decode_strkey_from_reader() {
+    // `from_reader` consumes a stream and cannot borrow keys from the input.
+    let json = r#"{"public_key_ed25519":"3330317ec241d79943bb9aa7c8ea5f8b89f9c6ea351fe03f8ec3d1127137d484"}"#;
+    let Decoded(strkey): Decoded<Strkey> = serde_json::from_reader(json.as_bytes()).unwrap();
+    assert!(matches!(strkey, Strkey::PublicKeyEd25519(_)));
+}
+
+#[test]
+fn test_decode_strkey_from_value_nested_variant() {
+    // A compound variant (nested object) exercised through the owned-key path.
+    let value = serde_json::json!({
+        "signed_payload_ed25519": {
+            "ed25519": "0000000000000000000000000000000000000000000000000000000000000000",
+            "payload": "01020304",
+        }
+    });
+    let Decoded(strkey): Decoded<Strkey> = serde_json::from_value(value).unwrap();
+    assert!(matches!(strkey, Strkey::SignedPayloadEd25519(_)));
+}
+
+#[test]
+fn test_roundtrip_public_key_via_value() {
+    // Serialize to a `serde_json::Value`, then deserialize back via `from_value`.
+    let original = Strkey::PublicKeyEd25519(ed25519::PublicKey([7u8; 32]));
+    let value = serde_json::to_value(Decoded(&original)).unwrap();
+    let Decoded(deserialized): Decoded<Strkey> = serde_json::from_value(value).unwrap();
+    assert_eq!(original, deserialized);
+}
+
 #[test]
 fn test_roundtrip_muxed_account() {
     let original = Strkey::MuxedAccountEd25519(ed25519::MuxedAccount {

--- a/tests/serde_decoded.rs
+++ b/tests/serde_decoded.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "cli")]
+#![cfg(feature = "serde-decoded")]
 
 use stellar_strkey::{ed25519, *};
 
@@ -127,7 +127,8 @@ fn test_ed25519_signed_payload() {
 // yield owned (rather than borrowed) string keys. `serde_json::from_str`
 // borrows the variant key directly from the input buffer, but `from_value` and
 // `from_reader` cannot, so the map visitor must accept an owned key. The
-// `encode` CLI hits this via `from_value`. See issue #124.
+// `encode` CLI is one consumer that hits this, via `from_value`. See issue
+// #124.
 
 #[test]
 fn test_decode_strkey_from_value() {


### PR DESCRIPTION
### What

Read the variant key in the `Decoded<Strkey>` deserializer as an owned string instead of a borrowed `&str`, so the type can be deserialized from any serde data format rather than only from deserializers that borrow keys out of a contiguous input buffer.

### Why

The `Decoded<Strkey>` map visitor read its variant key as a borrowed `&str`, which only succeeds when the deserializer can hand back a slice borrowed directly from the input (`serde_json::from_str`, or `from_slice` on unescaped input). Any deserializer that produces owned keys — `serde_json::from_value`, `serde_json::from_reader`, and most non-JSON formats such as CBOR or bincode — failed immediately with `invalid type: string "...", expected a borrowed string`. This made the `encode` CLI unusable for every input, because it parses stdin into a `serde_json::Value` and then calls `from_value`, and it broke the same deserialization path for library consumers on the `serde-decoded` feature. The failure went unnoticed because the existing round-trip tests only exercised `from_str`, which borrows; this change adds regression coverage through the `from_value` and `from_reader` paths, including a nested compound variant. Close #124

### Known limitations

N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1AMDTWnWq5XfuNCRovhcy)_